### PR TITLE
Correct and subsequently update spelling of neutral student name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,7 @@ jobs:
           git config --global user.name 'Songbird Bot'
           git config --global user.email 'itsektionen-webmaster@users.noreply.github.com'
           git add dist
-          git commit -m "\
-          ${{ steps.commit-title.outputs.out }}\
-          \n\n\
-          Build was created as a result of commit ${{ github.event.workflow_run.head_commit.id }}\n[skip actions]"
+          git commit -m "${{ steps.commit-title.outputs.out }}" \
+          -m "Build was created as a result of commit ${{ github.event.workflow_run.head_commit.id }}" \
+          -m "[skip actions]"
           git push

--- a/songs/10_Jag_har_aldrig.md
+++ b/songs/10_Jag_har_aldrig.md
@@ -75,7 +75,7 @@ fastän dom inget alls ju förstå.
 
 Hela Handels borde rivas,
 detta anser hela vårat lag.
-Då skull' Osqurulda trivas,
+Då skull' Osquarina trivas,
 uppå denna Handels ljuva domedag.
 
 //: Och vilket drag! På denna dag!

--- a/src/github/songChanges.ts
+++ b/src/github/songChanges.ts
@@ -8,7 +8,7 @@ export default async function (): Promise<boolean> {
 	if (typeof lastUpdatedAt !== 'string' || !lastUpdatedAt.match(isoDateRegex)) return true;
 
 	const songs = createSongs(lastUpdatedAt);
-	if (songs.json !== oldSongs.json) return true;
+	if ((await songs.json) !== oldSongs.json) return true;
 	if (songs.xml !== oldSongs.xml) return true;
 	if (songs.xmlNoIds !== oldSongs.xmlNoIds) return true;
 


### PR DESCRIPTION
In the before times the student body at KTH were nicknamed `Osquar` or `Osqulda` depending on gender.\
In or about 2018 we updated this to `Osquar` and `Quristina`, at the same time as `Osquldas Väg` at the main campus was renamed.

This resulted in the "gender neutral" nickname changing to `Osquarina` (though I'm hard-pressed to find where the neutral was changed explicitly).

The old "neutral" version of the student nickname was `Osquarulda`, and not `Osqurulda`, so it turns out that the song book had a fudged spelling of the old neutral, and was way out of date.

[Link to THS' Union Council 17/18 archive, can't link directly to KF-05 but there is where you should look.](https://drive.google.com/drive/folders/1LVYSdXrGwAOpMnlF6jVePWbbUGWMO1ig)