### PR TITLE
Add more Author tags for consistent formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ All files are named and contain two sections, YAML front matter first and conten
 The front matter is contained by one line with `---` each before and after the section. Possible fields in the front matter are:
 
 - `title`, the name or title of the song **(required)**
-- `author`, the person or persons who wrote the lyrics of the song
+- `author`, information about the person or persons who wrote the lyrics of the song
+  - `name`, the name of the person or persons who wrote the lyrics of the song
+  - `event`, the event for which the song was made
+  - `location`, the city or university where the song is from
+  - `year`, the year the song was written
+  - `comment`, a comment about the author (for example, if an author wrote one of the verses)
 - `melody`, the melody the song is sung to
 - `composer`, the composer of the melody
 - `tags`, list of categories the songs fall in to and other identifiers (valid tags can be found in [`/src/definitions/tags.ts`](/src/definitions/tags.ts#L1-L12)) **(required)**
@@ -85,7 +90,11 @@ Any field without a value should be omitted.
 ```yml
 ---
 title: Moder Kista
-author: David Larsson, IT00
+author:
+  - name: David Larsson, IT-00
+    event: IT-nØllningen
+    location: KTH
+    year: 2000
 melody: Längtan till landet
 composer: Otto Lindblad
 tags: [gasque, swe]
@@ -164,12 +173,17 @@ Builds files. Can optionally provide a date in the [ISO 8601](https://en.wikiped
 
 #### `yarn script create [title]`
 
-Creates a new song with the next possible ID and the given title. Front matter becomes populated with empty fields to make it as easy as possible to add them in. Optionally values to fields can be provided when running the script, e.g. `yarn script create "Moder Kista" --author="David Larsson, IT00" --tags=gasque` will have the following front matter:
+Creates a new song with the next possible ID and the given title. Front matter becomes populated with empty fields to make it as easy as possible to add them in. Optionally values to fields can be provided when running the script, e.g. `yarn script create "Moder Kista" --author="David Larsson, IT-00" --tags=gasque` will have the following front matter:
 
 ```yaml
 ---
 title: Moder Kista
-author: David Larsson, IT00
+author:
+  - name: David Larsson, IT-00
+    event:
+    location:
+    year:
+    comment:
 melody:
 composer:
 tags: [gasque]
@@ -284,6 +298,12 @@ Fronten har en rad med `---` före och efter sektionen. Möjliga fält i fronten
 
 - `title`, namnet eller titeln på sången **(obligatorisk)**
 - `author`, personen eller personerna som skrev sångtexten
+- `author`, information om personen eller personerna som skrev sångtexten
+  - `name`, personen eller personerna som skrev sångtexten
+  - `event`, evenemanget sången skrevs till
+  - `location`, staden eller universitetet som sången kommer ifrån
+  - `year`, året sången skrevs
+  - `comment`, kommentar om skribenten (exempelvis om en skribent har skrivit en av verserna)
 - `melody`, melodin som sången sjungs i
 - `composer`, kompositör till melodin
 - `tags`, lista med kategorier som sångerna tillhör och andra identifierare (giltiga taggar hittas i [`/src/definitions/tags.ts`](/src/definitions/tags.ts#L1-L12)) **(obligatorisk)**
@@ -297,7 +317,11 @@ Alla fält utan värde bör utelämnas.
 ```yml
 ---
 title: Moder Kista
-author: David Larsson, IT00
+author:
+  - name: David Larsson, IT-00
+    event: IT-nØllningen
+    location: KTH
+    year: 2000
 melody: Längtan till landet
 composer: Otto Lindblad
 tags: [gasque, swe]
@@ -377,12 +401,17 @@ Kompilerar filer. Man kan valfritt ange ett datum i formatet [ISO 8601](https://
 
 #### `yarn script create [titel]`
 
-Skapar en ny sång med nästa möjliga ID och den givna titeln. Fronten fylls med tomma fält för att göra är så enkelt som möjligt att fylla i dem. Valfritt kan värden till fält tillhandahållas när man kör skriptet, t.ex. `yarn script create "Moder Kista" --author="David Larsson, IT00" --tags=gasque` kommer att ha följande front:
+Skapar en ny sång med nästa möjliga ID och den givna titeln. Fronten fylls med tomma fält för att göra är så enkelt som möjligt att fylla i dem. Valfritt kan värden till fält tillhandahållas när man kör skriptet, t.ex. `yarn script create "Moder Kista" --author="David Larsson, IT-00" --tags=gasque` kommer att ha följande front:
 
 ```yaml
 ---
 title: Moder Kista
-author: David Larsson, IT00
+author:
+  - name: David Larsson, IT-00
+    event:
+    location:
+    year:
+    comment:
 melody:
 composer:
 tags: [gasque]

--- a/dist/songs-no-ids.xml
+++ b/dist/songs-no-ids.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<songs description="IN-sektionens sångbok, Strängteoretiquernas reviderade version (2009-2015)" updated="2025-03-13">
+<songs description="IT-sektionens sångbok, Strängteoretiquernas reviderade version (2009-2015)" updated="2025-03-20">
 	<song
 		name="Moder Kista"
-		author="David Larsson, IT00"
+		author="David Larsson, IT-00 (KTH, 2000)"
 		composer="Otto Lindblad"
 		melody="Längtan till landet"
 		category="Gasque"
@@ -45,8 +45,8 @@
 		</p>
 	</song>
 	<song
-		name="Dance macabre"
-		author="Carl-Erik Carlstedt, Chalmers"
+		name="Danse macabre"
+		author="Carl-Erik Carlstedt (Chalmers)"
 		melody="Vårvindar friska"
 		category="Gasque"
 	>
@@ -77,7 +77,7 @@
 	</song>
 	<song
 		name="Porthos visa"
-		author="Tore Norén, Bergsspexet, 1960"
+		author="Tord Andrén, B (Bergsspexet, KTH, 1960 — Ursprungligen Athos visa)"
 		composer="Irving Berlin"
 		melody="You can't get a man with a gun"
 		category="Gasque"
@@ -111,7 +111,7 @@
 	</song>
 	<song
 		name="Jag ska festa"
-		author="Stefan 'Stege' Gennert och Anders 'Pellefjant' Bjerkén, Sångarstriden Lund, 1987"
+		author="Stefan 'Stege' Gennert, D-86, och Anders 'Pellefjant' Bjerkén, D-87 (Sångarstriden, Lund, 1987)"
 		composer="Sten Carlberg"
 		melody="Bamsesången"
 		category="Gasque"
@@ -149,7 +149,7 @@
 	</song>
 	<song
 		name="Lyft ditt välförsedda glas"
-		author="Medicinarspexet Göteborg, 1970"
+		author="(Medicinarspexet, Göteborg, 1970)"
 		composer="Jehan Tabourot, George Ratcliffe Woodward, Charles Wood"
 		melody="Ding dong merrily on high"
 		category="Gasque"
@@ -180,7 +180,7 @@
 	</song>
 	<song
 		name="Fredmans sång nr. 21"
-		author="Carl Michael Bellman"
+		author="Carl Michael Bellman (1787)"
 		composer="Carl Michael Bellman"
 		category="Gasque"
 	>
@@ -301,7 +301,7 @@
 	</song>
 	<song
 		name="Härjarevisan"
-		author="Lundaspexet Djingis Khan, 1954"
+		author="(Lundaspexet Djingis Khan, 1954)"
 		melody="Gärdebylåten"
 		category="Gasque"
 	>
@@ -394,7 +394,7 @@
 	</song>
 	<song
 		name="Système International"
-		author="Anders Skog, F-75"
+		author="Anders Skog, F-75 (KTH)"
 		composer="Prins Gustaf av Sverige och Norge"
 		melody="Studentsången"
 		category="Gasque"
@@ -411,9 +411,9 @@
 	</song>
 	<song
 		name="Jag har aldrig..."
-		author="(Handelsvisan) Team Kangaroo, 1977; (Fysikvisan) DKM, 2000; (Datavisan) Mattis Castegren, 2001"
-		composer="Joël Blomqvist och Per Ollén"
-		melody="O hur saligt att få vandra"
+		author="Team Kangaroo, F (Gerhards-gasque, KTH, 1977 — Handelsvisan); DKM (KTH, 2000 — Fysikvisan); Mattis Castegren (Fysiksektionens Ettans fest, KTH, 2001 — Datavisan)"
+		composer="Robert Lowry"
+		melody="O, hur saligt att få vandra"
 		category="Gasque"
 	>
 		<p>
@@ -768,7 +768,7 @@
 	</song>
 	<song
 		name="Lille Olle"
-		author="Calle Isaksson, D-LiTH"
+		author="Calle Isaksson, D (LiTH)"
 		composer="Matvey Blanter"
 		melody="Katjuscha"
 		category="Gasque"
@@ -822,7 +822,7 @@
 	</song>
 	<song
 		name="När jag är fuller"
-		author="Sångartäflan, 1942"
+		author="Tore 'Pekka' Norén, B (Sångartäflan, KTH, 1942)"
 		melody="När månen vandrar"
 		category="Gasque"
 	>
@@ -877,7 +877,7 @@
 	</song>
 	<song
 		name="Störthärligt full"
-		author="Hittad på Handels, 1981"
+		author="(1981 — Hittad på Handels)"
 		composer="Povel Ramel"
 		melody="Fat Mammy Brown"
 		category="Gasque"
@@ -955,7 +955,7 @@
 	</song>
 	<song
 		name="Bort allt vad oro gör"
-		author="Carl Michael Bellman"
+		author="Carl Michael Bellman (1783 — Bacchi Tempel sång nr. 17)"
 		composer="Carl Michael Bellman"
 		category="Gasque"
 	>
@@ -1146,7 +1146,7 @@
 	</song>
 	<song
 		name="Anti-snapsvisa"
-		author="Lundakarnevalen, 1986"
+		author="(Lundakarnevalen, 1986)"
 		composer="Evert Taube"
 		melody="Sjösala vals"
 		category="Gasque"
@@ -1166,7 +1166,7 @@
 	</song>
 	<song
 		name="Cidervisan"
-		author="Strängteoretiquerna, 2015"
+		author="Strängteoretiquerna, IT (KTH, 2015)"
 		composer="Thorbjørn Egner"
 		melody="Rövarnas visa"
 		category="Gasque"
@@ -1198,7 +1198,7 @@
 	</song>
 	<song
 		name="Vi tar en enkel liten sång"
-		author="Strängteoretiquerna, 2015"
+		author="Strängteoretiquerna, IT (KTH, 2015)"
 		composer="Jules Sylvain och Sven Paddock"
 		melody="Med en enkel tulipan"
 		category="Gasque"
@@ -1219,7 +1219,7 @@
 	</song>
 	<song
 		name="Treo-comp"
-		author="Lundakarnevalen, 1986"
+		author="(Lundakarnevalen, 1986)"
 		composer="Otto Lindblad"
 		melody="Längtan till landet"
 		category="Gasque"
@@ -1281,7 +1281,7 @@
 	</song>
 	<song
 		name="Vit vecka"
-		author="Sångarstriden Lund, 1992"
+		author="(Sångarstriden, Lund, 1992)"
 		composer="Irving Berlin"
 		melody="White Christmas"
 		category="Gasque"
@@ -1346,7 +1346,7 @@
 	</song>
 	<song
 		name="Viking Raiders"
-		author="Samuel Larsson (2020)"
+		author="Samuel Larsson, IT (KTH, 2020)"
 		melody="Spanish Ladies"
 		category="Gasque"
 	>
@@ -1696,7 +1696,7 @@
 	</song>
 	<song
 		name="Öppna en öhl"
-		author="Carl Brengesjö, 2013"
+		author="Carl Brengesjö (KTH, 2013)"
 		composer="Tommy Nilsson"
 		melody="Öppna din dörr"
 		category="Öhl"
@@ -1836,7 +1836,7 @@
 	</song>
 	<song
 		name="Elysisk längtan"
-		author="Sångarstriden Lund, 1968"
+		author="(Sångarstriden, Lund, 1968)"
 		composer="Ludwig van Beethoven"
 		melody="An die Freude (Ode to Joy)"
 		category="Wihn"
@@ -1981,7 +1981,7 @@
 	</song>
 	<song
 		name="Längtan till landet"
-		author="Herman Sätherberg och Otto Lindblad"
+		author="Herman Sätherberg och Otto Lindblad (1838)"
 		composer="Herman Sätherberg och Otto Lindblad"
 		category="Wihn"
 	>
@@ -2038,7 +2038,7 @@
 	</song>
 	<song
 		name="Tjugotre"
-		author="Carl Nisser, E-80"
+		author="Carl Nisser, E-80 (KTH)"
 		melody="Amanda Lundbom"
 		category="Brännvin"
 	>
@@ -2326,7 +2326,7 @@
 	</song>
 	<song
 		name="Livet är härligt"
-		author="Chalmersspexet Katarina II, 1959"
+		author="(Chalmersspexet Katarina II, 1959)"
 		composer="Lev Knipper"
 		melody="Röda kavalleriet (Polyushko-Pole)"
 		category="Brännvin"
@@ -2360,7 +2360,7 @@
 	</song>
 	<song
 		name="Vikingen"
-		author="Sångarstriden, Lund, 1981"
+		author="E-Sektionen (Sångarstriden, Lund, 1981)"
 		melody="When Johnny comes marching home"
 		category="Brännvin"
 	>
@@ -2566,7 +2566,7 @@
 	</song>
 	<song
 		name="Gräv ur tundran"
-		author="Ekonomspexet Lenin, 1989"
+		author="(Ekonomspexet Lenin, Stockholms universitet, 1989)"
 		composer="Matvey Blanter"
 		melody="Katjuscha"
 		category="Brännvin"
@@ -2691,7 +2691,7 @@
 	</song>
 	<song
 		name="Häv, häv detta glas"
-		author="Erik Rålenius"
+		author="Erik Rålenius, IT (KTH)"
 		composer="Alice Tegnér"
 		melody="Bä, bä vita lamm"
 		category="Brännvin"
@@ -2706,7 +2706,7 @@
 	</song>
 	<song
 		name="Spritbolaget"
-		author="Göran Svensson, Sångarstriden Lund, 1989"
+		author="Göran Svensson (Sångarstriden, Lund, 1989)"
 		composer="Georg Riedel"
 		melody="Du käre lille snickerboa"
 		category="Brännvin"
@@ -2734,7 +2734,7 @@
 	</song>
 	<song
 		name="Rackaren"
-		author="Kårspexet Munken, 1983"
+		author="(Kårspexet Munken, KTH, 1983)"
 		composer="Georg Philipp Telemann"
 		melody="Hamburger Ebb und Fluth"
 		category="Brännvin"
@@ -2750,7 +2750,7 @@
 	</song>
 	<song
 		name="Ganska nykter"
-		author="Strängteoretiquerna, 2015"
+		author="Strängteoretiquerna, IT (KTH, 2015)"
 		melody="Vi äro musikanter"
 		category="Brännvin"
 	>
@@ -2764,7 +2764,7 @@
 	</song>
 	<song
 		name="Hyllningsvisa till Absinthen"
-		author="Sing-Sing Singers, 2000"
+		author="Sing-Sing Singers (KTH, 2000)"
 		melody="O come all ye faithful"
 		category="Brännvin"
 	>
@@ -2791,7 +2791,7 @@
 	</song>
 	<song
 		name="Man kan dricka vatten"
-		author="Datas nØllespex, 1995"
+		author="(Datas nØllespex, KTH, 1995)"
 		melody="Vi äro musikanter"
 		category="Brännvin"
 	>
@@ -2837,7 +2837,7 @@
 	</song>
 	<song
 		name="Ode till halvan"
-		author="Torgny, 1936"
+		author="Torgny (1936)"
 		composer="Otto Lindblad"
 		melody="Längtan till landet"
 		category="Brännvin"
@@ -2879,7 +2879,7 @@
 	</song>
 	<song
 		name="Regalskeppet Vasa"
-		author="Den Kongliga INviten"
+		author="Den Kongliga invITen (KTH)"
 		composer="Leigh Harline"
 		melody="Ser du stjärnan i det blå"
 		category="Brännvin"
@@ -3017,8 +3017,10 @@
 		</p>
 	</song>
 	<song
-		name="FESTU:s punschvisa"
-		melody="Tomtarnas vinternatt"
+		name="FestU:s punschvisa"
+		author="FestU (Chalmers)"
+		composer="Vilhelm Sefve-Svensson"
+		melody="Tomtarnas julnatt"
 		category="Punsch"
 	>
 		<p>
@@ -3224,6 +3226,7 @@
 	</song>
 	<song
 		name="P.U.S.S.:s punschvisa"
+		author="P.U.S.S."
 		composer="Tommy Nilsson"
 		melody="Öppna din dörr"
 		category="Punsch"
@@ -3321,7 +3324,7 @@
 	</song>
 	<song
 		name="När kaffet är serverat"
-		author="Sångarstriden Lund, 1987"
+		author="(Sångarstriden, Lund, 1987)"
 		composer="Christian Hartmann"
 		melody="Mössens julafton"
 		category="Punsch"
@@ -3371,7 +3374,7 @@
 	</song>
 	<song
 		name="Härlig är punschen"
-		author="Juristspexet Ansgar, 2003"
+		author="(Juristspexet Ansgar, 2003)"
 		melody="Nu grönskar det"
 		category="Punsch"
 	>
@@ -3398,7 +3401,7 @@
 	</song>
 	<song
 		name="Nu blotas det"
-		author="Juristspexet Ansgar, 2003"
+		author="(Juristspexet Ansgar, 2003)"
 		composer="Johann Sebastian Bac"
 		melody="Nu grönskar det"
 		category="Punsch"
@@ -3426,7 +3429,7 @@
 	</song>
 	<song
 		name="Imperial punsch"
-		author="DKM, 2000"
+		author="DKM (KTH, 2000)"
 		composer="John Williams"
 		melody="Imperial march, Star Wars"
 		category="Punsch"
@@ -3484,6 +3487,7 @@
 	</song>
 	<song
 		name="Sveriges arraktionalhymn"
+		author="(Ekonomspexet Erik XIV, Stockholms universitet, 1992)"
 		melody="Du gamla, du fria"
 		category="Punsch"
 	>
@@ -3517,7 +3521,7 @@
 	</song>
 	<song
 		name="I Love Punsch"
-		author="Samuel Larsson (2020)"
+		author="Samuel Larsson, IT (KTH, 2020)"
 		composer="Ben Oakland and Milton Drake"
 		melody="Java Jive"
 		category="Punsch"
@@ -3965,7 +3969,8 @@
 	</song>
 	<song
 		name="My heart will go on"
-		author="Celine Dion"
+		author="Celine Dion (1997)"
+		composer="James Horner"
 		category="Utländskt"
 	>
 		<p>
@@ -4162,7 +4167,7 @@
 	</song>
 	<song
 		name="Man ska ha Linux"
-		author="Erik Rålenius"
+		author="Erik Rålenius, IT (KTH)"
 		composer="Claes Eriksson"
 		melody="Man ska ha husvagn"
 		category="Nördigt"
@@ -4226,7 +4231,7 @@
 	</song>
 	<song
 		name="Om Emacs"
-		author="Ingemar Ragnemalm"
+		author="Ingemar Ragnemalm (LiU)"
 		melody="Kovan kommer, kovan går"
 		category="Nördigt"
 	>
@@ -4258,7 +4263,7 @@
 	<song
 		name="Ostkaka"
 		composer="Jeremy Soule"
-		melody="Dovahkin, Skyrim theme"
+		melody="Dovahkin (Skyrim theme)"
 		category="Nördigt"
 	>
 		<p>
@@ -4285,7 +4290,7 @@
 	</song>
 	<song
 		name="Jag kan lära dig C"
-		author="Arian och Sixten (DISK KM), DISK KM:s julfest 2011"
+		author="Arian och Sixten (DISK KM:s julfest, Stockholms universitet, 2011)"
 		composer="Alan Menken"
 		melody="A Whole New World"
 		category="Nördigt"
@@ -4316,7 +4321,7 @@
 	</song>
 	<song
 		name="Write in C"
-		author="Jay Piecora, SUNY Binghamton"
+		author="Jay Piecora (SUNY Binghamton)"
 		composer="John Lennon, Paul McCartney"
 		melody="Let It Be"
 		category="Nördigt"
@@ -4364,7 +4369,7 @@
 	</song>
 	<song
 		name="Pop opp i topp"
-		author="Thore Skogman, 1965"
+		author="Thore Skogman (1965)"
 		category="Esoterica"
 	>
 		<p>
@@ -4423,7 +4428,7 @@
 	</song>
 	<song
 		name="PRAOs visa"
-		author="Niklas Söderlund och Wilhelm Svenselius"
+		author="Niklas Söderlund och Wilhelm Svenselius, IT-03 (KTH)"
 		melody="När månen vandrar"
 		category="Esoterica"
 	>
@@ -4440,7 +4445,7 @@
 	</song>
 	<song
 		name="Vår flygpilot"
-		author="Dain Nilsson"
+		author="Dain Nilsson, IT-04 (KTH)"
 		melody="Oh Tannenbaum"
 		category="Esoterica"
 	>
@@ -4455,7 +4460,7 @@
 	</song>
 	<song
 		name="Farväl till IT-sektionen"
-		author="Dain Nilsson och Erik Rålenius"
+		author="Dain Nilsson, IT-04, och Erik Rålenius, IT (KTH)"
 		melody="Uti vår hage"
 		category="Esoterica"
 	>
@@ -4489,7 +4494,7 @@
 	</song>
 	<song
 		name="IN-sektionen"
-		author="Dain Nilsson och Erik Rålenius"
+		author="Dain Nilsson, IT-04, och Erik Rålenius, IT (KTH)"
 		composer="Aleksander Aleksandrov"
 		melody="Rysslands nationalsång"
 		category="Esoterica"
@@ -4511,7 +4516,7 @@
 	</song>
 	<song
 		name="Faddersången 2001"
-		author="Kjell Ahlström"
+		author="Kjell Ahlström (KTH, 2001)"
 		composer="Elizabeth Cotten"
 		melody="SJ, SJ, gamle vän"
 		category="Esoterica"
@@ -4540,14 +4545,11 @@
 			Bron den utgör gränsens strand
 			till farligt ghettoland.
 		</p>
-		<comment>
-			Den sista versen delades ut på separata lappar i bussen och skall därför betraktas
-			som inofficiell.
-		</comment>
+		<comment>Den sista versen delades ut på separata lappar i bussen och skall därför betraktas som inofficiell.</comment>
 	</song>
 	<song
 		name="Läs inte på Handels"
-		author="Alex Ellgren och Oscar Frick"
+		author="Alex Ellgren, ME-07, och Oscar Frick, ME-07 (KTH)"
 		category="Esoterica"
 	>
 		<p>
@@ -4673,7 +4675,7 @@
 	</song>
 	<song
 		name="Sång till Stor-MUX"
-		author="Erik Lundberg och Wilhelm Svenselius"
+		author="Erik Lundberg och Wilhelm Svenselius, IT-03 (KTH)"
 		melody="Balladen om Theobald Thor"
 		category="Esoterica"
 	>
@@ -4737,7 +4739,7 @@
 	</song>
 	<song
 		name="Bacchivisan"
-		author="Kjell Ahlström"
+		author="Kjell Ahlström (KTH)"
 		melody="Agadoo (ungefär)"
 		category="Esoterica"
 	>
@@ -4829,7 +4831,7 @@
 	</song>
 	<song
 		name="Tentavakten"
-		author="Erik Rålenius"
+		author="Erik Rålenius, IT (KTH)"
 		melody="Du gamla, du fria"
 		category="Esoterica"
 	>
@@ -4851,7 +4853,7 @@
 	</song>
 	<song
 		name="Vart tog den schlema lilla nØllan vägen?"
-		author="Kjell Ahlström"
+		author="Kjell Ahlström (KTH)"
 		melody="Vart tog den söta lilla flickan vägen"
 		category="Esoterica"
 	>
@@ -4941,7 +4943,7 @@
 	</song>
 	<song
 		name="Starke Arvid"
-		author="Ola, Frukt och Flingor, 1979"
+		author="Ola, Frukt och Flingor (1979)"
 		category="Esoterica"
 	>
 		<p>
@@ -4994,7 +4996,7 @@
 	</song>
 	<song
 		name="Man ska gå ME"
-		author="Viktor Åberg"
+		author="Viktor Åberg (KTH)"
 		composer="Claes Eriksson"
 		melody="Man ska ha husvagn"
 		category="Esoterica"
@@ -5042,7 +5044,7 @@
 	</song>
 	<song
 		name="Osqvik"
-		author="Strängteoretiquerna, 2015"
+		author="Strängteoretiquerna, IT (KTH, 2015)"
 		melody="Vi äro musikanter"
 		category="Esoterica"
 	>
@@ -5127,7 +5129,7 @@
 	</song>
 	<song
 		name="invITensången"
-		author="Daniel Byström"
+		author="Daniel Byström (KTH)"
 		composer="Otto Lindblad"
 		melody="Kungssången"
 		category="Högtidligt"
@@ -5155,7 +5157,7 @@
 	</song>
 	<song
 		name="Kungssången"
-		author="C.V.A.Strandberg och Otto Lindblad, 1844"
+		author="C.V.A.Strandberg och Otto Lindblad (1844)"
 		category="Högtidligt"
 	>
 		<p>
@@ -5172,7 +5174,7 @@
 	</song>
 	<song
 		name="Stockholm i mitt hjärta"
-		author="Lasse Berghagen"
+		author="Lasse Berghagen (1995)"
 		category="Högtidligt"
 	>
 		<p>
@@ -5220,7 +5222,7 @@
 	</song>
 	<song
 		name="Du gamla, du fria"
-		author="Richard Dybeck, 1844"
+		author="Richard Dybeck (1844)"
 		category="Högtidligt"
 	>
 		<p>
@@ -5240,8 +5242,8 @@
 	</song>
 	<song
 		name="O, gamla klang- och jubeltid!"
-		author="August Lindh, 1921"
-		composer="Eugen Höfling, 1825"
+		author="August Lindh (Juvenalorden, Uppsala, 1921)"
+		composer="Eugen Höfling (1825)"
 		melody="O alte Burschenherrlichkeit"
 		category="Högtidligt"
 	>

--- a/dist/songs-no-ids.xml
+++ b/dist/songs-no-ids.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<songs description="IT-sektionens sångbok, Strängteoretiquernas reviderade version (2009-2015)" updated="2025-03-20">
+<songs description="IT-sektionens sångbok, Strängteoretiquernas reviderade version (2009-2015)" updated="2025-03-22">
 	<song
 		name="Moder Kista"
-		author="David Larsson, IT-00 (KTH, 2000)"
+		author="David Larsson, IT-00 (IT-nØllningen, KTH, 2000)"
 		composer="Otto Lindblad"
 		melody="Längtan till landet"
 		category="Gasque"
@@ -111,7 +111,7 @@
 	</song>
 	<song
 		name="Jag ska festa"
-		author="Stefan 'Stege' Gennert, D-86, och Anders 'Pellefjant' Bjerkén, D-87 (Sångarstriden, Lund, 1987)"
+		author="Stefan "Stege" Gennert, D-86, och Anders "Pellefjant" Bjerkén, D-87 (Sångarstriden, Lund, 1987)"
 		composer="Sten Carlberg"
 		melody="Bamsesången"
 		category="Gasque"
@@ -575,7 +575,7 @@
 	</song>
 	<song
 		name="Jag var full en gång..."
-		composer="Hugo Lindh, Gösta 'Snoddas' Nordgren"
+		composer="Hugo Lindh, Gösta "Snoddas" Nordgren"
 		melody="Flottarkärlek"
 		category="Gasque"
 	>
@@ -822,7 +822,7 @@
 	</song>
 	<song
 		name="När jag är fuller"
-		author="Tore 'Pekka' Norén, B (Sångartäflan, KTH, 1942)"
+		author="Tore "Pekka" Norén, B (Sångartäflan,, KTH,, 1942)"
 		melody="När månen vandrar"
 		category="Gasque"
 	>
@@ -1346,7 +1346,7 @@
 	</song>
 	<song
 		name="Viking Raiders"
-		author="Samuel Larsson, IT (KTH, 2020)"
+		author="Samuel Larsson, IT-17 (KTH, 2020)"
 		melody="Spanish Ladies"
 		category="Gasque"
 	>
@@ -1981,8 +1981,8 @@
 	</song>
 	<song
 		name="Längtan till landet"
-		author="Herman Sätherberg och Otto Lindblad (1838)"
-		composer="Herman Sätherberg och Otto Lindblad"
+		author="Herman Sätherberg (1838)"
+		composer="Otto Lindblad"
 		category="Wihn"
 	>
 		<p>
@@ -3375,6 +3375,7 @@
 	<song
 		name="Härlig är punschen"
 		author="(Juristspexet Ansgar, 2003)"
+		composer="Johann Sebastian Bach"
 		melody="Nu grönskar det"
 		category="Punsch"
 	>
@@ -3402,7 +3403,7 @@
 	<song
 		name="Nu blotas det"
 		author="(Juristspexet Ansgar, 2003)"
-		composer="Johann Sebastian Bac"
+		composer="Johann Sebastian Bach"
 		melody="Nu grönskar det"
 		category="Punsch"
 	>
@@ -3431,7 +3432,7 @@
 		name="Imperial punsch"
 		author="DKM (KTH, 2000)"
 		composer="John Williams"
-		melody="Imperial march, Star Wars"
+		melody="Imperial march (Star Wars)"
 		category="Punsch"
 	>
 		<p>
@@ -3521,7 +3522,7 @@
 	</song>
 	<song
 		name="I Love Punsch"
-		author="Samuel Larsson, IT (KTH, 2020)"
+		author="Samuel Larsson, IT-17 (KTH, 2020)"
 		composer="Ben Oakland and Milton Drake"
 		melody="Java Jive"
 		category="Punsch"
@@ -3541,7 +3542,7 @@
 	</song>
 	<song
 		name="Barrett's Privateers"
-		author="Stan Rogers"
+		author="Stan Rogers (1976)"
 		category="Utländskt"
 	>
 		<p>
@@ -4130,7 +4131,7 @@
 	</song>
 	<song
 		name="Unix Man"
-		author="Bran Morrison"
+		author="Brad Morrison"
 		composer="John Lennon and Paul McCartney"
 		melody="Nowhere Man"
 		category="Nördigt"
@@ -4322,7 +4323,7 @@
 	<song
 		name="Write in C"
 		author="Jay Piecora (SUNY Binghamton)"
-		composer="John Lennon, Paul McCartney"
+		composer="John Lennon och Paul McCartney"
 		melody="Let It Be"
 		category="Nördigt"
 	>
@@ -4676,7 +4677,7 @@
 	<song
 		name="Sång till Stor-MUX"
 		author="Erik Lundberg och Wilhelm Svenselius, IT-03 (KTH)"
-		melody="Balladen om Theobald Thor"
+		melody="The Ball of Kirriemuir (Balladen om Theobald Thor)"
 		category="Esoterica"
 	>
 		<p>

--- a/dist/songs.json
+++ b/dist/songs.json
@@ -7,7 +7,7 @@
 			"composer": "Otto Lindblad",
 			"tags": ["gasque", "swe"],
 			"content": "Ack för Kista brinner våra hjärtan,\ncentrum för vår I-Teknologi.\nAlla sorger sopas under mattan,\nnär vårt Kista vi flanerar i.\n\nSjung för alla stolta basstationer,\nsjung för Forums vackra arkitektur.\nLåt oss därför celebrera vår moder:\nKista, du förstärker vår bravur!\n\nIfrån Kista trampas nya stigar,\nmorgondagsteknik är vår gebit.\nÅr för år, vi fortsätter att vara\nblickfång för global teknikelit.\n\nHär föds många nya forskningsgenier,\nskarpa sinnen väcks och strålar med glans.\nNu har turen blivit vår att stoltsera,\nnu är tiden här att ta vår chans.\n\nAck för Kista brinner våra hjärtan,\nallas stämmor, klara höjs mot skyn.\nHögt från ovan science tower tronar i sin prakt;\ndet är en ståtlig syn.\n\nNu system och minnen byggas på kisel,\nstora ingenjörer följer vårt spår.\nSå med styrka vi för världen nu visar:\nVi är här och framtiden är vår!",
-			"author": "David Larsson, IT-00 (KTH, 2000)"
+			"author": "David Larsson, IT-00 (IT-nØllningen, KTH, 2000)"
 		},
 		{
 			"id": 1,
@@ -33,7 +33,7 @@
 			"composer": "Sten Carlberg",
 			"tags": ["gasque", "swe"],
 			"content": "Jag ska festa, ta det lungt med spriten.\nHa det roligt utan att bli full.\nInte krypa runt med festeliten.\nTa det varligt för min egen skull.\n\nFörst en öl i torra stupen,\nefter det så kommer supen,\nner med vinet, i med punschen,\nsist en groggbuffé.\n\nJag är skitfull, däckar först av alla\nMissar festen, men vad gör väl det?\nBlandar hejdlöst öl och gammal filmjölk.\nKastar upp på bordsdamen breve'!\n\nFörst en öl i torra strupen,\nefter det så kommer supen,\nner med vinet, i med punschen,\nsist en groggbuffé.\n\nSpyan rinner ner för ylleslipsen,\nraviolin torkar i mitt hår.\nVem har lagt mig här i pissoaren,\nvems är gaffeln i mitt högra lår?",
-			"author": "Stefan 'Stege' Gennert, D-86, och Anders 'Pellefjant' Bjerkén, D-87 (Sångarstriden, Lund, 1987)"
+			"author": "Stefan \"Stege\" Gennert, D-86, och Anders \"Pellefjant\" Bjerkén, D-87 (Sångarstriden, Lund, 1987)"
 		},
 		{
 			"id": 4,
@@ -98,7 +98,7 @@
 			"id": 11,
 			"title": "Jag var full en gång...",
 			"melody": "Flottarkärlek",
-			"composer": "Hugo Lindh, Gösta 'Snoddas' Nordgren",
+			"composer": "Hugo Lindh, Gösta \"Snoddas\" Nordgren",
 			"tags": ["gasque", "swe"],
 			"content": "Jag var full en gång för länge sen,\npå knäna kröp jag hem.\nVarje dike var för mig ett vilohem,\nvilohem!\n\nI varje hörn och varje vrå,\nhade jag en liten vän,\nifrån renat upp till nittosex procent,\n-sex procent!\n\nJag var full en gång för länge sen,\npå knäna kröp jag hem,\noch i sällskap hade jag en elefant,\nelefant!\n\nElefanten spruta' vatten,\noch jag trodde det var öl,\nsedan dess har alla kallat mig för knöl.\nMera öl!\n\nJag var full en gång för länge sen,\npå knäna kröp jag hem,\noch i sällskap hade jag en elefant,\nelefant!\n\nElefanten spruta' vatten,\noch jag trodde det var vin,\nsedan dess har alla kallat mig för svin.\nMera vin!\n\nJag var full en gång för länge sen,\npå knäna kröp jag hem,\noch i sällskap hade jag en elefant,\nelefant!\n\nElefanten spruta' vatten,\noch jag trodde det var sprit,\nsedan dess har alla kallat mig för skit.\nMera sprit!"
 		},
@@ -130,7 +130,7 @@
 			"melody": "När månen vandrar",
 			"tags": ["gasque", "swe"],
 			"content": "När jag är fuller då är jag glad,\nfan vet om jag ej är vacker.\nJag vandrar kring i vår lilla stad,\nibland lyxhus och baracker.\n\nJag sjunger ljuvligt en serenad.\ndet gör jag bara när jag är glad\noch full och vacker,\noch full och vacker.\n\nNär jag är fuller då är jag stark,\nfan vet om jag ej är modig.\nDå kan jag slå vem som helst i mark,\nså han blir trasig och blodig.\n\nJag välter träden i våran park.\ndet gör jag bara när jag är stark\noch full och modig,\noch full och modig.\n\nNär jag är fuller då år jag rik\nfan vet om jag ej är snille.\nOch dör jag blir jag ett vackert lik,\nbegravs med gravöl och gille.\n\nI himlen möts jag av hornmusik,\ndet gör man bara när man är rik\noch är ett snille,\noch är ett snille.\n\nMen när jag vaknar upp nästa dag,\nuppå ett enkelrum med galler.\nDå känner jag mig så rysligt svag,\noch hatar bråk och kravaller.\n\nMin mage krånglar och är ur lag,\nnog fan så vet jag att jag idag\när bakom galler,\när bakom galler.",
-			"author": "Tore 'Pekka' Norén, B (Sångartäflan, KTH, 1942)"
+			"author": "Tore \"Pekka\" Norén, B (Sångartäflan,, KTH,, 1942)"
 		},
 		{
 			"id": 16,
@@ -259,7 +259,7 @@
 			"melody": "Spanish Ladies",
 			"tags": ["gasque", "eng"],
 			"content": "Farewell and adieu to you danish ladies\nFarewell and adieu to you lovely Danes\nFor we’re under orders to sail off to England\nWe hope in a short time to see you again\n\nWe’ll rant and we’ll roar like true viking raiders\nWe’ll plunder the shores along the north sea\nUntil we strike soundings in the channel o’ England\nFrom Valland to London ‘tis forty-five leagues\n\nWe hove our ship to, with the wind from sou’west, crew.\nWe hove our ship to, deep soundings to take.\n‘Twas twenty-one fathoms, with a murky mud bottom\nAnd bore right away, crew, and up river did make.\n\nWe’ll rant and we’ll roar...\n\nWe pull out our ships, gettin’ hold of our weapons.\nWe pull out our ships, preparing to raid.\nOur sights set on London, to get all of ’er gold.\nWhen we find the old city, we leave her in flames.\n\nWe’ll rant and we’ll roar...\n\nNow let every man drink off his full bumper\nAnd let every man drink off his full glass\nWe’ll drink and be jolly and drown melancholy\nHere’s to the health of each true-hearted lass\n\nWe’ll rant and we’ll roar...",
-			"author": "Samuel Larsson, IT (KTH, 2020)"
+			"author": "Samuel Larsson, IT-17 (KTH, 2020)"
 		},
 		{
 			"id": 31,
@@ -453,10 +453,10 @@
 		{
 			"id": 55,
 			"title": "Längtan till landet",
-			"composer": "Herman Sätherberg och Otto Lindblad",
+			"composer": "Otto Lindblad",
 			"tags": ["wine", "swe"],
 			"content": "Vintern rasat ut bland våra fjällar,\ndrivans blommor smälta ned och dö.\nHimlen ler i vårens ljusa kvällar,\nsolen kysser liv i skog och sjö.\nSnart är sommarn här i purpurvågor,\nguldbelagda, azurskiftande,\nligga ängarne i dagens lågor,\noch i lunden dansa källorne.\n\nJa, jag kommer! Hälsen glada vindar,\nut till landet, ut till fåglarne,\natt jag älskar dem, till björk och lindar,\nsjö och berg jag vill dem återse.\nSe dem än som i min barndoms stunder,\nfölja bäckens dans till klarnad sjö.\nTrastens sång i furuskogens lunder,\nvattenfågelns lek kring fjärd och ö.",
-			"author": "Herman Sätherberg och Otto Lindblad (1838)"
+			"author": "Herman Sätherberg (1838)"
 		},
 		{
 			"id": 56,
@@ -906,6 +906,7 @@
 			"id": 110,
 			"title": "Härlig är punschen",
 			"melody": "Nu grönskar det",
+			"composer": "Johann Sebastian Bach",
 			"tags": ["punsch", "swe"],
 			"content": "Nu blotas det i stad och land,\nnu är midsommartid.\nDräp ko, dräp häst, det är jättefest\nse blod överallt och bredvid.\nVart djur som dör ger bättre skörd,\nse där har vi ju ett svin!\nJa, dräp nu allt, dräp ko och galt\noch taxar och braxar och bin.\n\nRakt fram mot offrets gråa bord\nvi glatt vår kossa styr.\nVi slaktar Bambi och Stampe med,\nse upp så att Bamse ej flyr.\nI gyllne dryck så skålar vi\nnär vi står i det blod som vi skvätt.\nDet där det var gott, får man mer om man ber?\nJa, punsch uti blodet känns rätt.",
 			"author": "(Juristspexet Ansgar, 2003)"
@@ -914,7 +915,7 @@
 			"id": 111,
 			"title": "Nu blotas det",
 			"melody": "Nu grönskar det",
-			"composer": "Johann Sebastian Bac",
+			"composer": "Johann Sebastian Bach",
 			"tags": ["punsch", "swe"],
 			"content": "Nu blotas det i stad och land,\nnu är midsommartid.\nDräp ko, dräp häst, det är jättefest\nse blod överallt och bredvid.\nVart djur som dör ger bättre skörd,\nse där har vi ju ett svin!\nJa, dräp nu allt, dräp ko och galt\noch taxar och braxar och bin.\n\nRakt fram mot offrets gråa bord\nvi glatt vår kossa styr.\nVi slaktar Bambi och Stampe med,\nse upp så att Bamse ej flyr.\nI gyllne dryck så skålar vi\nnär vi står i det blod som vi skvätt.\nDet där det var gott, får man mer om man ber?\nJa, punsch uti blodet känns rätt.",
 			"author": "(Juristspexet Ansgar, 2003)"
@@ -922,7 +923,7 @@
 		{
 			"id": 112,
 			"title": "Imperial punsch",
-			"melody": "Imperial march, Star Wars",
+			"melody": "Imperial march (Star Wars)",
 			"composer": "John Williams",
 			"tags": ["punsch", "swe"],
 			"content": "Punsch, punsch, punsch, mera punsch, mera punsch!\nPunsch, punsch, punsch, mera punsch, mera punsch!\nPunsch, punsch, punsch, mera, mera punsch!\nMer punsch, mera, mera punsch,\nmer punsch, mera punsch, punsch, punsch!",
@@ -959,14 +960,14 @@
 			"composer": "Ben Oakland and Milton Drake",
 			"tags": ["punsch", "eng"],
 			"content": "I love punsch in bites of three\nI love the punsch bottle and it loves me\nArrack and tea, makes the punsch just for me\nA shot, a shot, a shot, a shot, a shot\n\nI love punsch filling my cup\nI love the golden drops, I lick ‘em up\nNow flip the cup and punsch lovers drink up\nA shot, a shot, a shot, a shot, a shot",
-			"author": "Samuel Larsson, IT (KTH, 2020)"
+			"author": "Samuel Larsson, IT-17 (KTH, 2020)"
 		},
 		{
 			"id": 114,
 			"title": "Barrett's Privateers",
 			"tags": ["foreign", "eng"],
 			"content": "Kan sjungas med sångledare, då sjunger alla raderna som börjar med \"\\*\", sångledaren i\növrigt solo.\nO the year was 17-78!\n\\*How I wish I was in Sherbrooke now!\nA letter of marque came from the king,\nto the scummiest vessel I'd ever seen!\n\n\\*God damn them all!\n\\*I was told we'd cruise the seas for american gold!\n\\*We'd fire no guns, shed no tears!\n\\*Now I'm a broken man on a Halifax pier,\n\\*the last of Barrett's privateers.\n\nO Elcid Barrett cried the town.\n\\*How I wish I was in Sherbrooke now!\nFor twenty brave men, all fishermen who\nwould make for him the Antelope's crew.\n\n\\*God damn them all ...\n\nThe Antelope sloop was a sickening sight.\n\\*How I wish I was in Sherbrooke now!\nShe'd a list to the port and her sails in rags\nand the cook in the scuppers\nwith the staggers and jags!\n\n\\*God damn them all ...\n\nOn the king's birthday we put to sea.\n\\*How I wish I was in Sherbrooke now!\nWe were ninety-one days to Montego Bay,\npumping like madmen all the way.\n\n\\*God damn them all ...\n\nOn 96th day we sailed again.\n\\*How I wish I was in Sherbrooke now!\nWhen a bloody great yankee hove in sight,\nwith our cracked four-pounders we made to fight.\n\n\\*God damn them all ...\n\nThe yankee lay low down with gold.\n\\*How I wish I was in Sherbrooke now!\nShe was broad and fat and loose in the stays,\nbut to catch her took the Antelope two whole days.\n\n\\*God damn them all ...\n\nThen at length we stood, two cables away.\n\\*How I wish I was in Sherbrooke now!\nOur cracked four-pounders made an awful din,\nbut with one fat ball the yank stove us in.\n\n\\*God damn them all ...\n\nThe Antelope shook and pitched on her side.\n\\*How I wish I was in Sherbrooke now!\nBarrett was smashed like a bowl of eggs,\nand the main-truck carried off both me legs.\n\n*God damn them all!\n*I was told we'd cruise the seas for american gold!\n*We'd fire no guns, shed no tears!\n*Now I'm a broken man on a Halifax pier,\n\\*the last of Barrett's privateers.\n\nNow here I lay in my 23rd year.\n\\*How I wish I was in Sherbrooke now!\nIt's been six long years since we sailed away,\nand I just made Halifax yesterday.\n\n\\*God damn them all ...",
-			"author": "Stan Rogers"
+			"author": "Stan Rogers (1976)"
 		},
 		{
 			"id": 115,
@@ -1037,7 +1038,7 @@
 			"composer": "John Lennon and Paul McCartney",
 			"tags": ["nerdy", "eng"],
 			"content": "He's a real UNIX Man,\nsitting in his UNIX LAN,\nmaking all his UNIX .plans\nfor nobody.\n\nKnows the blocksize from 'du'.\nCares not where /dev/null goes to.\nIsn't he a bit like you and me?\n\nUNIX Man, don't worry.\nIt's the tube that's blurry.\nUNIX Man,\nthe new kernel boots,\njust like you had planned.\n\nHe's as wise as he can be.\nPrograms in lex, yacc and C.\nUNIX Man, can you help me at all?\n\nUNIX Man, please listen.\nMy printout is missin'.\nUNIX Man,\nthe wo-o-o-orld is your 'at' command.",
-			"author": "Bran Morrison"
+			"author": "Brad Morrison"
 		},
 		{
 			"id": 125,
@@ -1077,7 +1078,7 @@
 			"id": 161,
 			"title": "Write in C",
 			"melody": "Let It Be",
-			"composer": "John Lennon, Paul McCartney",
+			"composer": "John Lennon och Paul McCartney",
 			"tags": ["nerdy", "eng"],
 			"content": "When I find my code in tons of trouble,\nfriends and colleagues come to me,\nspeaking words of wisdom: “Write in C.”\n\nAs the deadline fast approaches,\nand bugs are all that I can see,\nsomewhere, someone whispers: “Write in C.”\n\nWrite in C, write in C,\nwrite in C, oh, write in C.\nLOGO's dead and buried, write in C.\n\nI used to write a lot of FORTRAN;<\nfor science it worked flawlessly.\nTry using it for graphics! Write in C.\n\nIf you've just spent nearly 30 hours\ndebugging some assembly,\nsoon you will be glad to write in C.\n\nWrite in C, write in C,\nwrite in C, yeah, write in C.\nOnly wimps use BASIC, write in C.\n\nWrite in C, write in C,\nwrite in C, oh, write in C.\nPascal won't quite cut it, write in C.\n\nWrite in C, write in C,\nwrite in C, yeah, write in C.\nDon't even mention COBOL. Write in C.",
 			"author": "Jay Piecora (SUNY Binghamton)"
@@ -1149,7 +1150,7 @@
 		{
 			"id": 136,
 			"title": "Sång till Stor-MUX",
-			"melody": "Balladen om Theobald Thor",
+			"melody": "The Ball of Kirriemuir (Balladen om Theobald Thor)",
 			"tags": ["esoteric", "swe"],
 			"content": "En MUX som hette Ann-Sofi Åhn,\nhon hade en stekpanna av Teflon,\nI den la' hon sin mobiltelefon\nsom genast sprängdes med schwung!\n\nDet var ett stort schwung!\nLångt, kraftigt och tungt!\nFrån dess topp till dess rot, var det tre fyra fot\noch en medelstor ryggsäck till\nschwung, schwung, schwung,\nschwungeli schwung,\nschwung, schwung schwung...\n\nNu har hon ingen telefon,\nhon fick köpa sig en megafon.\nSe'n skrek hon i sin mikrofon\nså att ingen fick sova en blund!\n\nDet var en stor blund...\n\nKassören han blev helt bestört,\ninvITen skrek nåt' oerhört,\nPhöz tog varsin citodon\noch tystade Ann-Sofi Åhn!\n\nDet var en stor Åhn...\n\nMen phöz tar inte Ann-Sofi!\nDe fick allt göra snabb sorti\noch Överphöz till sjukan går\nför att vårda ett sår på sitt lår.\n\nDet var ett stort lår...\n\ninvITen dom gick också bet.\nI Ann-Sofi dom drog och slet,\nförlorade kampen och gick på lunch\nför att dricka en flaska med punsch!\n\nDet var en stor punsch...\n\nAllt hopp vi ställde till vår kassör,\nhan vet hur storMUXen tämjas bör.\nHan öppnade fort ett sopnedkast\noch hystade henne med hast!\n\nDet var en stor hast...\n\nFast sagan fick ett lyckligt slut,\nen faxmaskin vi köpte ut\nav märket Konglig Electrolux\nsen skänkte vi den till vår MUX!\n\nDet var en stor MUX...",
 			"author": "Erik Lundberg och Wilhelm Svenselius, IT-03 (KTH)"
@@ -1270,5 +1271,5 @@
 			"content": "> Sjunges alltid som gasquens sista sång.\n\nHur gärna ville jag ej vara,\nen liten blå förgätmigej,\nen liten blå förgätmigej!\n\nDå skulle jag för dig förklara,\nhur innerligt jag älskar dig!"
 		}
 	],
-	"updatedAt": "2025-03-20"
+	"updatedAt": "2025-03-22"
 }

--- a/dist/songs.json
+++ b/dist/songs.json
@@ -3,62 +3,62 @@
 		{
 			"id": 0,
 			"title": "Moder Kista",
-			"author": "David Larsson, IT00",
 			"melody": "Längtan till landet",
 			"composer": "Otto Lindblad",
 			"tags": ["gasque", "swe"],
-			"content": "Ack för Kista brinner våra hjärtan,\ncentrum för vår I-Teknologi.\nAlla sorger sopas under mattan,\nnär vårt Kista vi flanerar i.\n\nSjung för alla stolta basstationer,\nsjung för Forums vackra arkitektur.\nLåt oss därför celebrera vår moder:\nKista, du förstärker vår bravur!\n\nIfrån Kista trampas nya stigar,\nmorgondagsteknik är vår gebit.\nÅr för år, vi fortsätter att vara\nblickfång för global teknikelit.\n\nHär föds många nya forskningsgenier,\nskarpa sinnen väcks och strålar med glans.\nNu har turen blivit vår att stoltsera,\nnu är tiden här att ta vår chans.\n\nAck för Kista brinner våra hjärtan,\nallas stämmor, klara höjs mot skyn.\nHögt från ovan science tower tronar i sin prakt;\ndet är en ståtlig syn.\n\nNu system och minnen byggas på kisel,\nstora ingenjörer följer vårt spår.\nSå med styrka vi för världen nu visar:\nVi är här och framtiden är vår!"
+			"content": "Ack för Kista brinner våra hjärtan,\ncentrum för vår I-Teknologi.\nAlla sorger sopas under mattan,\nnär vårt Kista vi flanerar i.\n\nSjung för alla stolta basstationer,\nsjung för Forums vackra arkitektur.\nLåt oss därför celebrera vår moder:\nKista, du förstärker vår bravur!\n\nIfrån Kista trampas nya stigar,\nmorgondagsteknik är vår gebit.\nÅr för år, vi fortsätter att vara\nblickfång för global teknikelit.\n\nHär föds många nya forskningsgenier,\nskarpa sinnen väcks och strålar med glans.\nNu har turen blivit vår att stoltsera,\nnu är tiden här att ta vår chans.\n\nAck för Kista brinner våra hjärtan,\nallas stämmor, klara höjs mot skyn.\nHögt från ovan science tower tronar i sin prakt;\ndet är en ståtlig syn.\n\nNu system och minnen byggas på kisel,\nstora ingenjörer följer vårt spår.\nSå med styrka vi för världen nu visar:\nVi är här och framtiden är vår!",
+			"author": "David Larsson, IT-00 (KTH, 2000)"
 		},
 		{
 			"id": 1,
-			"title": "Dance macabre",
-			"author": "Carl-Erik Carlstedt, Chalmers",
+			"title": "Danse macabre",
 			"melody": "Vårvindar friska",
 			"tags": ["gasque", "swe"],
-			"content": "Runt kring vår stuga smådjävlar sluga,\ntassa så tyst med bockfot och svans.\nVarulvar yla, isande kyla,\nsveper i dimman fanstygens dans.\n\nBäva, o broder, lyssna och hör,\nvrålen från gast, som osalig dör.\nSatan han skrattar, flaskan han fattar,\nsuper tills dagen gryr.\n\nGastar och spöken skymtar i kröken,\ndödingar släpa ruttnande lik.\nBenrangel skramla, spökhänder famla,\nkväva din strupes rosslande skrik.\n\nHelvetes alla fasor släpps loss,\nFan rider här med hela sin tross.\nGöm dig i stugan, du har fått flugan,\ndille det blir din lott."
+			"content": "Runt kring vår stuga smådjävlar sluga,\ntassa så tyst med bockfot och svans.\nVarulvar yla, isande kyla,\nsveper i dimman fanstygens dans.\n\nBäva, o broder, lyssna och hör,\nvrålen från gast, som osalig dör.\nSatan han skrattar, flaskan han fattar,\nsuper tills dagen gryr.\n\nGastar och spöken skymtar i kröken,\ndödingar släpa ruttnande lik.\nBenrangel skramla, spökhänder famla,\nkväva din strupes rosslande skrik.\n\nHelvetes alla fasor släpps loss,\nFan rider här med hela sin tross.\nGöm dig i stugan, du har fått flugan,\ndille det blir din lott.",
+			"author": "Carl-Erik Carlstedt (Chalmers)"
 		},
 		{
 			"id": 2,
 			"title": "Porthos visa",
-			"author": "Tore Norén, Bergsspexet, 1960",
 			"melody": "You can't get a man with a gun",
 			"composer": "Irving Berlin",
 			"tags": ["gasque", "swe"],
-			"content": "Jag vill börja gasqua,\nvart fan är min flaska?\nVem i helvete stal min butelj?\n\nSka törsten mig tvinga,\nen TT börja svinga?\nNej för fan, bara blunda och svälj!\n\nVilken smörja! Får jag spörja?\nVem för fan tror att jag är en älg?\n\nTill England vi rider,\noch sedan vad det lider\nträffar vi välan på någon pub?\n\nOch där ska vi festa,\nblott dricka av det bästa:\nUtav whiskey och portvin,\njag tänker gå hårt in\nför att prova på rubb och stubb!"
+			"content": "Jag vill börja gasqua,\nvart fan är min flaska?\nVem i helvete stal min butelj?\n\nSka törsten mig tvinga,\nen TT börja svinga?\nNej för fan, bara blunda och svälj!\n\nVilken smörja! Får jag spörja?\nVem för fan tror att jag är en älg?\n\nTill England vi rider,\noch sedan vad det lider\nträffar vi välan på någon pub?\n\nOch där ska vi festa,\nblott dricka av det bästa:\nUtav whiskey och portvin,\njag tänker gå hårt in\nför att prova på rubb och stubb!",
+			"author": "Tord Andrén, B (Bergsspexet, KTH, 1960 — Ursprungligen Athos visa)"
 		},
 		{
 			"id": 3,
 			"title": "Jag ska festa",
-			"author": "Stefan 'Stege' Gennert och Anders 'Pellefjant' Bjerkén, Sångarstriden Lund, 1987",
 			"melody": "Bamsesången",
 			"composer": "Sten Carlberg",
 			"tags": ["gasque", "swe"],
-			"content": "Jag ska festa, ta det lungt med spriten.\nHa det roligt utan att bli full.\nInte krypa runt med festeliten.\nTa det varligt för min egen skull.\n\nFörst en öl i torra stupen,\nefter det så kommer supen,\nner med vinet, i med punschen,\nsist en groggbuffé.\n\nJag är skitfull, däckar först av alla\nMissar festen, men vad gör väl det?\nBlandar hejdlöst öl och gammal filmjölk.\nKastar upp på bordsdamen breve'!\n\nFörst en öl i torra strupen,\nefter det så kommer supen,\nner med vinet, i med punschen,\nsist en groggbuffé.\n\nSpyan rinner ner för ylleslipsen,\nraviolin torkar i mitt hår.\nVem har lagt mig här i pissoaren,\nvems är gaffeln i mitt högra lår?"
+			"content": "Jag ska festa, ta det lungt med spriten.\nHa det roligt utan att bli full.\nInte krypa runt med festeliten.\nTa det varligt för min egen skull.\n\nFörst en öl i torra stupen,\nefter det så kommer supen,\nner med vinet, i med punschen,\nsist en groggbuffé.\n\nJag är skitfull, däckar först av alla\nMissar festen, men vad gör väl det?\nBlandar hejdlöst öl och gammal filmjölk.\nKastar upp på bordsdamen breve'!\n\nFörst en öl i torra strupen,\nefter det så kommer supen,\nner med vinet, i med punschen,\nsist en groggbuffé.\n\nSpyan rinner ner för ylleslipsen,\nraviolin torkar i mitt hår.\nVem har lagt mig här i pissoaren,\nvems är gaffeln i mitt högra lår?",
+			"author": "Stefan 'Stege' Gennert, D-86, och Anders 'Pellefjant' Bjerkén, D-87 (Sångarstriden, Lund, 1987)"
 		},
 		{
 			"id": 4,
 			"title": "Lyft ditt välförsedda glas",
-			"author": "Medicinarspexet Göteborg, 1970",
 			"melody": "Ding dong merrily on high",
 			"composer": "Jehan Tabourot, George Ratcliffe Woodward, Charles Wood",
 			"tags": ["gasque", "swe"],
-			"content": "Lyft ditt välförsedda glas,\ndet är en härlig börda!\nNu har grabbarna kalas,\nvi segern snart skall skörda!\n\n//: Dinge dingedingedinge\ndingedingedinge dingedingeding\ndong dong, imorgon är det lördag. ://\n\nSätt nu glaset till din mun,\nse döden på dig väntar!\nNu har grabbarna kalas,\nhör liemannen flämtar!\n\n//: Dinge dingedingedinge\ndingedingedinge dingedingeding\ndong dong, begravningsklockor\nklämtar. ://"
+			"content": "Lyft ditt välförsedda glas,\ndet är en härlig börda!\nNu har grabbarna kalas,\nvi segern snart skall skörda!\n\n//: Dinge dingedingedinge\ndingedingedinge dingedingeding\ndong dong, imorgon är det lördag. ://\n\nSätt nu glaset till din mun,\nse döden på dig väntar!\nNu har grabbarna kalas,\nhör liemannen flämtar!\n\n//: Dinge dingedingedinge\ndingedingedinge dingedingeding\ndong dong, begravningsklockor\nklämtar. ://",
+			"author": "(Medicinarspexet, Göteborg, 1970)"
 		},
 		{
 			"id": 5,
 			"title": "Fredmans sång nr. 21",
-			"author": "Carl Michael Bellman",
 			"composer": "Carl Michael Bellman",
 			"tags": ["gasque", "swe"],
-			"content": "Så lunka vi så småningom\nfrån Bacchi buller och tumult,\nnär döden ropar, Granne kom,\nditt timglas är nu fullt.\n\nDu Gubbe fäll din krycka ner,\noch du, du yngling, lyd min lag:\nDen skönsta nymf som åt dig ler\ninunder armen tag.\n\nTycker du att graven är för djup,\nnå välan så tag dig då en sup,\ntag dig sen dito en, dito två,\ndito tre, så dör du nöjdare.\n\nDu vid din remmare och press,\nrödbrusig och med hatt på sned,\nsnart skrider fram din likprocess\nI några svarta led;\n\nOch du som pratar där så stort,\nmed band och stjärnor på din rock:\nRe'n snickarn kistan färdig gjort,\noch hyvlar på des lock.\n\nTycker du...\n\nMen du som med en trumpen min,\nbland reglar, galler, järn och lås,\ndig vilar på ditt penningskrin,\ninom ditt stängda bås;\n\nOch du som svartsjuk slår i kras\nbuteljer, speglar och pokal;\nBjud nu god natt, drick ur ditt glas,\noch hälsa din rival:\n\nTycker du ...\n\nOch du som under titlars klang\ndin tiggarstav förgyllt vart år,\nsom knappast har, med all din rang,\nen skilling till din bår;\n\nOch du som ilsken, feg och lat,\nfördömer vaggan som dig välvt,\noch ändå dagligt är plakat\ntill glasets sista hälft;\n\nTycker du ...\n\nDu som vid Martis fältbasun\nI blodig skjorta sträckt ditt steg;\nOch du som tumlar i paulun,\nI Chloris armar feg;\n\nOch du som med din gyllne bok\nvid templets genljud reser dig,\nsom rister huvud lärd och klok,\noch för mot avgrund krig;\n\nTycker du att graven är för djup,\nnå välan så tag dig då en sup,\ntag dig sen dito en, dito två,\ndito tre, så dör du nöjdare.\n\nMen du som med en ärlig min\nplär dina vänner häda jämt,\noch dem förtalar vid ditt vin,\noch det liksom på skämt;\n\nOch du som ej försvarar dem,\nfastän ur deras flaskor du,\ndu väl kan slicka dina fem,\nvad svarar du väl nu?\n\nTycker du ...\n\nMen du som till din återfärd,\nifrån det du till bordet gick,\nEj klingat för din raska värd,\nfastän han ropar: Drick!\n\nDriv sådan gäst från mat och vin,\nkör honom med sitt anhang ut,\nOch sen med en ovänlig min,\nryck remmarn ur hans trut!\n\nTycker du ...\n\nSäg är du nöjd? Min granne säg,\nså prisa värden nu till slut;\nOm vi ha en och samma väg,\nså följoms åt; drick ut!\n\nMen först med vinet rött och vitt\nför vår värdinna bugom oss,\noch halkom sen i grafven fritt,\nvid aftonstjärnans bloss!\n\nTycker du ..."
+			"content": "Så lunka vi så småningom\nfrån Bacchi buller och tumult,\nnär döden ropar, Granne kom,\nditt timglas är nu fullt.\n\nDu Gubbe fäll din krycka ner,\noch du, du yngling, lyd min lag:\nDen skönsta nymf som åt dig ler\ninunder armen tag.\n\nTycker du att graven är för djup,\nnå välan så tag dig då en sup,\ntag dig sen dito en, dito två,\ndito tre, så dör du nöjdare.\n\nDu vid din remmare och press,\nrödbrusig och med hatt på sned,\nsnart skrider fram din likprocess\nI några svarta led;\n\nOch du som pratar där så stort,\nmed band och stjärnor på din rock:\nRe'n snickarn kistan färdig gjort,\noch hyvlar på des lock.\n\nTycker du...\n\nMen du som med en trumpen min,\nbland reglar, galler, järn och lås,\ndig vilar på ditt penningskrin,\ninom ditt stängda bås;\n\nOch du som svartsjuk slår i kras\nbuteljer, speglar och pokal;\nBjud nu god natt, drick ur ditt glas,\noch hälsa din rival:\n\nTycker du ...\n\nOch du som under titlars klang\ndin tiggarstav förgyllt vart år,\nsom knappast har, med all din rang,\nen skilling till din bår;\n\nOch du som ilsken, feg och lat,\nfördömer vaggan som dig välvt,\noch ändå dagligt är plakat\ntill glasets sista hälft;\n\nTycker du ...\n\nDu som vid Martis fältbasun\nI blodig skjorta sträckt ditt steg;\nOch du som tumlar i paulun,\nI Chloris armar feg;\n\nOch du som med din gyllne bok\nvid templets genljud reser dig,\nsom rister huvud lärd och klok,\noch för mot avgrund krig;\n\nTycker du att graven är för djup,\nnå välan så tag dig då en sup,\ntag dig sen dito en, dito två,\ndito tre, så dör du nöjdare.\n\nMen du som med en ärlig min\nplär dina vänner häda jämt,\noch dem förtalar vid ditt vin,\noch det liksom på skämt;\n\nOch du som ej försvarar dem,\nfastän ur deras flaskor du,\ndu väl kan slicka dina fem,\nvad svarar du väl nu?\n\nTycker du ...\n\nMen du som till din återfärd,\nifrån det du till bordet gick,\nEj klingat för din raska värd,\nfastän han ropar: Drick!\n\nDriv sådan gäst från mat och vin,\nkör honom med sitt anhang ut,\nOch sen med en ovänlig min,\nryck remmarn ur hans trut!\n\nTycker du ...\n\nSäg är du nöjd? Min granne säg,\nså prisa värden nu till slut;\nOm vi ha en och samma väg,\nså följoms åt; drick ut!\n\nMen först med vinet rött och vitt\nför vår värdinna bugom oss,\noch halkom sen i grafven fritt,\nvid aftonstjärnans bloss!\n\nTycker du ...",
+			"author": "Carl Michael Bellman (1787)"
 		},
 		{
 			"id": 6,
 			"title": "Härjarevisan",
-			"author": "Lundaspexet Djingis Khan, 1954",
 			"melody": "Gärdebylåten",
 			"tags": ["gasque", "swe"],
-			"content": "Liksom våra fäder vikingarna i Norden\ndrar vi landet runt och super oss under borden.\nBrännvinet har blitt ett elexir\nför kropp såväl som själ!\n\nKänner du dig liten och ynklig på jorden,\nväxer du med supen och blir stor uti orden,\nslår dig för ditt håriga bröst\noch blir en man från hår till häl!\n\nJa, nu skall vi ut och härja\nsupa och slåss och svärja\nbränna röda stugor, slå små barn\noch säga fula ord!\n\nMed blod skall vi stäppen färga\nNu änteligen lär ja'\nkunna dra nå'n verklig nytta\nav min Hermodskurs i mord.\n\nHurra, nu skall man äntligen få röra på benen,\nhela stammen jublar och det spritter i grenen,\ntänk att än en gång få spränga fram\npå Brunte i galopp!\n\nDin doft, o kära Brunte, är trots brist i hygienen,\nför en vild mongol minst lika ljuv som syrenen.\nTänk, att på din rygg få rida runt i stan och spela topp!\n\nJa, nu skall vi ut ...\n\nJa, mordbränder är klämmiga, ta fram fotogenen!\nEftersläckningen tillhör just de fenomenen\ninom brandmansyrket, som jag tycker är nån nytta med.\n\nJag målar för mitt inre upp den härliga scenen:\nBlodrött mitt i brandgult,\nej ens prins Eugen en lika mustig vy kan måla,\nens om han målade med sked!\n\nJa, nu ska vi ut..."
+			"content": "Liksom våra fäder vikingarna i Norden\ndrar vi landet runt och super oss under borden.\nBrännvinet har blitt ett elexir\nför kropp såväl som själ!\n\nKänner du dig liten och ynklig på jorden,\nväxer du med supen och blir stor uti orden,\nslår dig för ditt håriga bröst\noch blir en man från hår till häl!\n\nJa, nu skall vi ut och härja\nsupa och slåss och svärja\nbränna röda stugor, slå små barn\noch säga fula ord!\n\nMed blod skall vi stäppen färga\nNu änteligen lär ja'\nkunna dra nå'n verklig nytta\nav min Hermodskurs i mord.\n\nHurra, nu skall man äntligen få röra på benen,\nhela stammen jublar och det spritter i grenen,\ntänk att än en gång få spränga fram\npå Brunte i galopp!\n\nDin doft, o kära Brunte, är trots brist i hygienen,\nför en vild mongol minst lika ljuv som syrenen.\nTänk, att på din rygg få rida runt i stan och spela topp!\n\nJa, nu skall vi ut ...\n\nJa, mordbränder är klämmiga, ta fram fotogenen!\nEftersläckningen tillhör just de fenomenen\ninom brandmansyrket, som jag tycker är nån nytta med.\n\nJag målar för mitt inre upp den härliga scenen:\nBlodrött mitt i brandgult,\nej ens prins Eugen en lika mustig vy kan måla,\nens om han målade med sked!\n\nJa, nu ska vi ut...",
+			"author": "(Lundaspexet Djingis Khan, 1954)"
 		},
 		{
 			"id": 7,
@@ -79,20 +79,20 @@
 		{
 			"id": 9,
 			"title": "Système International",
-			"author": "Anders Skog, F-75",
 			"melody": "Studentsången",
 			"composer": "Prins Gustaf av Sverige och Norge",
 			"tags": ["gasque", "swe"],
-			"content": "W kg m Wb s\n\nΩ m T A rad\n\nCd S N s\n\nΩ A m Lx dB\n\n°C W/m²\n\nJ/kg H V C\n\nkg/m³ mol\n\nm/s² m/s²\n\nF!"
+			"content": "W kg m Wb s\n\nΩ m T A rad\n\nCd S N s\n\nΩ A m Lx dB\n\n°C W/m²\n\nJ/kg H V C\n\nkg/m³ mol\n\nm/s² m/s²\n\nF!",
+			"author": "Anders Skog, F-75 (KTH)"
 		},
 		{
 			"id": 10,
 			"title": "Jag har aldrig...",
-			"author": "(Handelsvisan) Team Kangaroo, 1977; (Fysikvisan) DKM, 2000; (Datavisan) Mattis Castegren, 2001",
-			"melody": "O hur saligt att få vandra",
-			"composer": "Joël Blomqvist och Per Ollén",
+			"melody": "O, hur saligt att få vandra",
+			"composer": "Robert Lowry",
 			"tags": ["gasque", "swe"],
-			"content": "Jag har aldrig vart på snusen,\naldrig rökat en cigarr, halleluja!\nMina dygder äro tusen,\ninga syndiga laster jag har.\n\nJag har aldrig sett nåt naket,\ninte ens ett litet nyfött barn!\n\nMina blickar går mot taket,\ndärmed undgår jag frestarens garn!\n\n//: Halleluja! Halleluja!\nHalleluja! Halleluja!\nHalleluja! Halleluja!\nHalleluja-a-ah! ://\n\nBacchus spelar på gitarren,\nSatan spelar på sitt handklaver!\nAlla djävlar dansar tango,\nsäg vad kan man väl önska sig mer?\n\nJo! Att alla bäckar vore brännvin,\nRiddarfjärden full av bayerskt öl.\nKonjak i varenda rännsten\noch punsch i varendaste pöl!\n\n//: Och mera öl! Vomera öl!\nOch mera öl! Vomera öl!\nOch mera öl! Vomera öl!\nOch mera ö-ö-öl! ://\n\n# Handelsvisan\n\nJag vill aldrig gå på Handels,\naldrig tenta företagsekonomi!\nDeras IQ är ju Mandels,\noch förståndet det har gjort sorti.\n\nDom har jätteusla snören,\ni sitt jätteusla draperi.\nDom kan bara räkna ören,\nhela Handels är ett jävla aperi!\n\n//: Handels är skit! Jag vill ej dit!\nHandels är skit! Jag vill ej dit!\nHandels är skit! Jag vill ej dit!\nHandels är ski-i-it! ://\n\nMammas pojkar är dom alla,\npappas flickor är dom likaså.\nGår och tror att dom e' balla,\nfastän dom inget alls ju förstå.\n\nHela Handels borde rivas,\ndetta anser hela vårat lag.\nDå skull' Osqurulda trivas,\nuppå denna Handels ljuva domedag.\n\n//: Och vilket drag! På denna dag!\nOch vilket drag! På denna dag!\nOch vilket drag! På denna dag!\nOch vilket dra-a-ag! ://\n\n# Fysikvisan\n\nJag vill aldrig gå på Fysik,\naldrig tenta termometerdynamik.\nJag vill inte höra syntmusik\neller festa som en jävla mattegeek!\n\nDom ser ut som televerket\ni sin jättefula overall.\nDom kan bara räkna kvarkar\nnu hyllar vi Data med en skål!\n\n//: Fysik är torrt! Jag vill ju bort!\nFysik är torrt! Jag vill ju bort!\nFysik är torrt! Jag vill ju bort!\nFysik är to-o-orrt! ://\n\nEinsteins pojkar är dom alla,\nHandels flickor kan dom aldrig få.\nGår och tror att dom har ballar,\ndet får bli på egen hand om det ska gå!\n\nNu ska hela Sing-Sing rivas,\narkitekt är med på Datas lag.\nTeleverket ska fördrivas,\nuppå konsulatets ljuva domedag.\n\n//: Och nubbedrag! På denna dag!\nOch nubbedrag! På denna dag!\nOch nubbedrag! På denna dag!\nOch nubbedra-a-ag! ://\n\n# Datavisan\n\nAlla vi som går på Data\nsitter mest och kodar Perl-script varje natt.\nMed oss kan man inte prata\nom man inte loggat in på någon chatt.\n\nVåran hy är grå som aska\nnär solen skiner sysslar vi med webdesign\noch när de andra börjat gasqua\nsitter vi och spelar Ultima Online.\n\n//: Datan är grå - visst är det så!\nDatan är trist - javisst, javisst!\nDatan är skit - man drar en nit\nom man går di-i-it! ://\n\nVi har något tomt i blicken,\nen hel skvadron av tomtar på vårt loft!\nIngen av oss har nån flickvän,\nmen vi drömmer varje natt om Lara Croft.\n\nData borde formateras,\nsystematiskt, partition för partition.\nNördarna dekompileras\noch uppgraderas till en användbar version.\n\n//: Datan är grå - visst är det så!\nDatan är trist - javisst, javisst!\nDatan är skit - man drar en nit\nom man går di-i-it! ://\n\n# Extravers för Kistastudenter\n\nJag vill aldrig gå i Kista,\naldrig tenta programmeringsmetodik.\n//: Vi kan bara iterera... :// (in abs.)\n\n> Finns fler verser för olika sektioner, men de sjungs vanligen inte av IN-sektionen."
+			"content": "Jag har aldrig vart på snusen,\naldrig rökat en cigarr, halleluja!\nMina dygder äro tusen,\ninga syndiga laster jag har.\n\nJag har aldrig sett nåt naket,\ninte ens ett litet nyfött barn!\n\nMina blickar går mot taket,\ndärmed undgår jag frestarens garn!\n\n//: Halleluja! Halleluja!\nHalleluja! Halleluja!\nHalleluja! Halleluja!\nHalleluja-a-ah! ://\n\nBacchus spelar på gitarren,\nSatan spelar på sitt handklaver!\nAlla djävlar dansar tango,\nsäg vad kan man väl önska sig mer?\n\nJo! Att alla bäckar vore brännvin,\nRiddarfjärden full av bayerskt öl.\nKonjak i varenda rännsten\noch punsch i varendaste pöl!\n\n//: Och mera öl! Vomera öl!\nOch mera öl! Vomera öl!\nOch mera öl! Vomera öl!\nOch mera ö-ö-öl! ://\n\n# Handelsvisan\n\nJag vill aldrig gå på Handels,\naldrig tenta företagsekonomi!\nDeras IQ är ju Mandels,\noch förståndet det har gjort sorti.\n\nDom har jätteusla snören,\ni sitt jätteusla draperi.\nDom kan bara räkna ören,\nhela Handels är ett jävla aperi!\n\n//: Handels är skit! Jag vill ej dit!\nHandels är skit! Jag vill ej dit!\nHandels är skit! Jag vill ej dit!\nHandels är ski-i-it! ://\n\nMammas pojkar är dom alla,\npappas flickor är dom likaså.\nGår och tror att dom e' balla,\nfastän dom inget alls ju förstå.\n\nHela Handels borde rivas,\ndetta anser hela vårat lag.\nDå skull' Osqurulda trivas,\nuppå denna Handels ljuva domedag.\n\n//: Och vilket drag! På denna dag!\nOch vilket drag! På denna dag!\nOch vilket drag! På denna dag!\nOch vilket dra-a-ag! ://\n\n# Fysikvisan\n\nJag vill aldrig gå på Fysik,\naldrig tenta termometerdynamik.\nJag vill inte höra syntmusik\neller festa som en jävla mattegeek!\n\nDom ser ut som televerket\ni sin jättefula overall.\nDom kan bara räkna kvarkar\nnu hyllar vi Data med en skål!\n\n//: Fysik är torrt! Jag vill ju bort!\nFysik är torrt! Jag vill ju bort!\nFysik är torrt! Jag vill ju bort!\nFysik är to-o-orrt! ://\n\nEinsteins pojkar är dom alla,\nHandels flickor kan dom aldrig få.\nGår och tror att dom har ballar,\ndet får bli på egen hand om det ska gå!\n\nNu ska hela Sing-Sing rivas,\narkitekt är med på Datas lag.\nTeleverket ska fördrivas,\nuppå konsulatets ljuva domedag.\n\n//: Och nubbedrag! På denna dag!\nOch nubbedrag! På denna dag!\nOch nubbedrag! På denna dag!\nOch nubbedra-a-ag! ://\n\n# Datavisan\n\nAlla vi som går på Data\nsitter mest och kodar Perl-script varje natt.\nMed oss kan man inte prata\nom man inte loggat in på någon chatt.\n\nVåran hy är grå som aska\nnär solen skiner sysslar vi med webdesign\noch när de andra börjat gasqua\nsitter vi och spelar Ultima Online.\n\n//: Datan är grå - visst är det så!\nDatan är trist - javisst, javisst!\nDatan är skit - man drar en nit\nom man går di-i-it! ://\n\nVi har något tomt i blicken,\nen hel skvadron av tomtar på vårt loft!\nIngen av oss har nån flickvän,\nmen vi drömmer varje natt om Lara Croft.\n\nData borde formateras,\nsystematiskt, partition för partition.\nNördarna dekompileras\noch uppgraderas till en användbar version.\n\n//: Datan är grå - visst är det så!\nDatan är trist - javisst, javisst!\nDatan är skit - man drar en nit\nom man går di-i-it! ://\n\n# Extravers för Kistastudenter\n\nJag vill aldrig gå i Kista,\naldrig tenta programmeringsmetodik.\n//: Vi kan bara iterera... :// (in abs.)\n\n> Finns fler verser för olika sektioner, men de sjungs vanligen inte av IN-sektionen.",
+			"author": "Team Kangaroo, F (Gerhards-gasque, KTH, 1977 — Handelsvisan); DKM (KTH, 2000 — Fysikvisan); Mattis Castegren (Fysiksektionens Ettans fest, KTH, 2001 — Datavisan)"
 		},
 		{
 			"id": 11,
@@ -111,11 +111,11 @@
 		{
 			"id": 13,
 			"title": "Lille Olle",
-			"author": "Calle Isaksson, D-LiTH",
 			"melody": "Katjuscha",
 			"composer": "Matvey Blanter",
 			"tags": ["gasque", "swe"],
-			"content": "Lille Olle skulle gå på disco,\nmen han hade inte någon sprit.\nLille Olle skaffa' lite hembränt.\nLille Olle gick då på en nit.\n\nLa lala la la ...\n\nLille Olle skulle börja festa.\nSpriten blandade han ut med Mer.\nLille Olle drack upp hela bålen.\nLille Olle ser nu inte mer.\n\nLa lala la la ...\n\nLille Olle skaffa sig en ledhund,\nden var ful och ganska trind.\nOlles ledhund drack upp 15 flaskor.\nOlles ledhund är nu också blind.\n\nLa lala la la ...\n\nLille Olle började med droger,\nblanda' ut sin LSD med juice.\nLille Olles hjärna står i lågor.\nLille Olle dog av överdos.\n\nLa lala la la ...\n\nLille Olle sitter nu i himlen,\nfesta kan man även göra där.\nLille Olle skaffade en ölback.\nCapsar nu med Gud och Sankte Per.\n\nLa lala la la ..."
+			"content": "Lille Olle skulle gå på disco,\nmen han hade inte någon sprit.\nLille Olle skaffa' lite hembränt.\nLille Olle gick då på en nit.\n\nLa lala la la ...\n\nLille Olle skulle börja festa.\nSpriten blandade han ut med Mer.\nLille Olle drack upp hela bålen.\nLille Olle ser nu inte mer.\n\nLa lala la la ...\n\nLille Olle skaffa sig en ledhund,\nden var ful och ganska trind.\nOlles ledhund drack upp 15 flaskor.\nOlles ledhund är nu också blind.\n\nLa lala la la ...\n\nLille Olle började med droger,\nblanda' ut sin LSD med juice.\nLille Olles hjärna står i lågor.\nLille Olle dog av överdos.\n\nLa lala la la ...\n\nLille Olle sitter nu i himlen,\nfesta kan man även göra där.\nLille Olle skaffade en ölback.\nCapsar nu med Gud och Sankte Per.\n\nLa lala la la ...",
+			"author": "Calle Isaksson, D (LiTH)"
 		},
 		{
 			"id": 14,
@@ -127,27 +127,27 @@
 		{
 			"id": 15,
 			"title": "När jag är fuller",
-			"author": "Sångartäflan, 1942",
 			"melody": "När månen vandrar",
 			"tags": ["gasque", "swe"],
-			"content": "När jag är fuller då är jag glad,\nfan vet om jag ej är vacker.\nJag vandrar kring i vår lilla stad,\nibland lyxhus och baracker.\n\nJag sjunger ljuvligt en serenad.\ndet gör jag bara när jag är glad\noch full och vacker,\noch full och vacker.\n\nNär jag är fuller då är jag stark,\nfan vet om jag ej är modig.\nDå kan jag slå vem som helst i mark,\nså han blir trasig och blodig.\n\nJag välter träden i våran park.\ndet gör jag bara när jag är stark\noch full och modig,\noch full och modig.\n\nNär jag är fuller då år jag rik\nfan vet om jag ej är snille.\nOch dör jag blir jag ett vackert lik,\nbegravs med gravöl och gille.\n\nI himlen möts jag av hornmusik,\ndet gör man bara när man är rik\noch är ett snille,\noch är ett snille.\n\nMen när jag vaknar upp nästa dag,\nuppå ett enkelrum med galler.\nDå känner jag mig så rysligt svag,\noch hatar bråk och kravaller.\n\nMin mage krånglar och är ur lag,\nnog fan så vet jag att jag idag\när bakom galler,\när bakom galler."
+			"content": "När jag är fuller då är jag glad,\nfan vet om jag ej är vacker.\nJag vandrar kring i vår lilla stad,\nibland lyxhus och baracker.\n\nJag sjunger ljuvligt en serenad.\ndet gör jag bara när jag är glad\noch full och vacker,\noch full och vacker.\n\nNär jag är fuller då är jag stark,\nfan vet om jag ej är modig.\nDå kan jag slå vem som helst i mark,\nså han blir trasig och blodig.\n\nJag välter träden i våran park.\ndet gör jag bara när jag är stark\noch full och modig,\noch full och modig.\n\nNär jag är fuller då år jag rik\nfan vet om jag ej är snille.\nOch dör jag blir jag ett vackert lik,\nbegravs med gravöl och gille.\n\nI himlen möts jag av hornmusik,\ndet gör man bara när man är rik\noch är ett snille,\noch är ett snille.\n\nMen när jag vaknar upp nästa dag,\nuppå ett enkelrum med galler.\nDå känner jag mig så rysligt svag,\noch hatar bråk och kravaller.\n\nMin mage krånglar och är ur lag,\nnog fan så vet jag att jag idag\när bakom galler,\när bakom galler.",
+			"author": "Tore 'Pekka' Norén, B (Sångartäflan, KTH, 1942)"
 		},
 		{
 			"id": 16,
 			"title": "Störthärligt full",
-			"author": "Hittad på Handels, 1981",
 			"melody": "Fat Mammy Brown",
 			"composer": "Povel Ramel",
 			"tags": ["gasque", "swe"],
-			"content": "Nu har alla lämnat festen\noch jag sitter ensam kvar\nibland groggar, pilsnerflaskor\ni en sönderslagen bar.\n\nSista pilsnerflaskan tog jag\ntill min frukost klockan fem\noch nu sitter jag och väntar\npå att få bli buren hem.\n\nFör jag är störthärligt full\noch jag ramlar mest omkull.\nJag ser rosa elefanter\nsom har jättekonstig ull.\n\nJa, jag är störthärligt full\noch jag ramlar mest omkull.\nDet är präktigt, härligt,\nsupa och va' full.\n\nIfrån fester minns jag inget,\nmen mitt öga blev visst blått.\nOch det måste jag ha fått\nnär någon kastat en karott\nfull med vispgrädde och fimpar\noch en okammad peruk,\neller också när jag stod\ni moraklockan och var sjuk.\n\nFör jag är störthärligt full\noch jag ramlar mest omkull.\nJag ser rosa elefanter\nsom har jättekonstig ull.\n\nJa, jag är störthärligt full\noch jag ramlar mest omkull.\nDet är präktigt, härligt,\nsupa och va' full.\n\nNästa morgon när jag vaknar\nmed en bergsborr i min kropp.\nSandpapper på tungan\noch jag vill ej stiga opp.\n\nMina armar dom känns tunga\noch min näsa den är sned.\nSå jag raglar ut till köket\nför en återställare.\n\nFör jag är störthärligt full\noch jag ramlar mest omkull.\nJag ser rosa elefanter\nsom har jättekonstig ull.\n\nJa, jag är störthärligt full\noch jag ramlar mest omkull.\nDet är präktigt, härligt,\nsupa och va' full."
+			"content": "Nu har alla lämnat festen\noch jag sitter ensam kvar\nibland groggar, pilsnerflaskor\ni en sönderslagen bar.\n\nSista pilsnerflaskan tog jag\ntill min frukost klockan fem\noch nu sitter jag och väntar\npå att få bli buren hem.\n\nFör jag är störthärligt full\noch jag ramlar mest omkull.\nJag ser rosa elefanter\nsom har jättekonstig ull.\n\nJa, jag är störthärligt full\noch jag ramlar mest omkull.\nDet är präktigt, härligt,\nsupa och va' full.\n\nIfrån fester minns jag inget,\nmen mitt öga blev visst blått.\nOch det måste jag ha fått\nnär någon kastat en karott\nfull med vispgrädde och fimpar\noch en okammad peruk,\neller också när jag stod\ni moraklockan och var sjuk.\n\nFör jag är störthärligt full\noch jag ramlar mest omkull.\nJag ser rosa elefanter\nsom har jättekonstig ull.\n\nJa, jag är störthärligt full\noch jag ramlar mest omkull.\nDet är präktigt, härligt,\nsupa och va' full.\n\nNästa morgon när jag vaknar\nmed en bergsborr i min kropp.\nSandpapper på tungan\noch jag vill ej stiga opp.\n\nMina armar dom känns tunga\noch min näsa den är sned.\nSå jag raglar ut till köket\nför en återställare.\n\nFör jag är störthärligt full\noch jag ramlar mest omkull.\nJag ser rosa elefanter\nsom har jättekonstig ull.\n\nJa, jag är störthärligt full\noch jag ramlar mest omkull.\nDet är präktigt, härligt,\nsupa och va' full.",
+			"author": "(1981 — Hittad på Handels)"
 		},
 		{
 			"id": 17,
 			"title": "Bort allt vad oro gör",
-			"author": "Carl Michael Bellman",
 			"composer": "Carl Michael Bellman",
 			"tags": ["gasque", "swe"],
-			"content": "Bort allt vad oro gör,\nbort allt vad hjärtat kväljer!\nBäst att man väljer\nbland dessa buteljer\nsin maglikör.\n\n//: Granne, gör du just som jag gör!\nVet, denna oljan ger humör.\nVad det var läckert!\nVad var det? Rhenskt bleckert?\n\"Oui, monseigneur!\" ://\n\nBort allt vad oro gör,\nallt är ju stoft och aska.\nLåt oss bli raska\noch tömma vår flaska\nbland bröderna!\n\n//: Granne, gör du just som jag gör!\nVet, denna oljan ger humör.\nVad det var mäktigt!\nVad var det? \"Jo, präktigt!\"\nMalaga? \"Ja!\" ://"
+			"content": "Bort allt vad oro gör,\nbort allt vad hjärtat kväljer!\nBäst att man väljer\nbland dessa buteljer\nsin maglikör.\n\n//: Granne, gör du just som jag gör!\nVet, denna oljan ger humör.\nVad det var läckert!\nVad var det? Rhenskt bleckert?\n\"Oui, monseigneur!\" ://\n\nBort allt vad oro gör,\nallt är ju stoft och aska.\nLåt oss bli raska\noch tömma vår flaska\nbland bröderna!\n\n//: Granne, gör du just som jag gör!\nVet, denna oljan ger humör.\nVad det var mäktigt!\nVad var det? \"Jo, präktigt!\"\nMalaga? \"Ja!\" ://",
+			"author": "Carl Michael Bellman (1783 — Bacchi Tempel sång nr. 17)"
 		},
 		{
 			"id": 18,
@@ -187,38 +187,38 @@
 		{
 			"id": 23,
 			"title": "Anti-snapsvisa",
-			"author": "Lundakarnevalen, 1986",
 			"melody": "Sjösala vals",
 			"composer": "Evert Taube",
 			"tags": ["gasque", "swe"],
-			"content": "Huvudet vi lyfter med ett stön ur vår säng,\ntvättmaskin i buken, kanoner i huvudet.\nTungan som en plyschsoffa och yrseln i sväng,\ni ångesten vi svettas kom sjung din refräng:\n\nVarför finns det aldrig nå'n nykter karneval?\nO, låt oss somna om så vi slipper våra kval.\nMen se, så många supar vi redan kastat upp i sängen\nRenat och Skåne, Svart Vinbär och fager Bäsk!"
+			"content": "Huvudet vi lyfter med ett stön ur vår säng,\ntvättmaskin i buken, kanoner i huvudet.\nTungan som en plyschsoffa och yrseln i sväng,\ni ångesten vi svettas kom sjung din refräng:\n\nVarför finns det aldrig nå'n nykter karneval?\nO, låt oss somna om så vi slipper våra kval.\nMen se, så många supar vi redan kastat upp i sängen\nRenat och Skåne, Svart Vinbär och fager Bäsk!",
+			"author": "(Lundakarnevalen, 1986)"
 		},
 		{
 			"id": 24,
 			"title": "Cidervisan",
-			"author": "Strängteoretiquerna, 2015",
 			"melody": "Rövarnas visa",
 			"composer": "Thorbjørn Egner",
 			"tags": ["gasque", "swe"],
-			"content": "Har ni hört, det finns en dryck\nsom görs på musterier.\nDen kan smaka sött och torrt\noch fyller skafferier.\nÄpple, päron, lime och bär,\nja, allt som ciderns frukter är.\nDe ligger och jäser och puttrar och fräser\noch skapar i tunnan en kärleksaffär.\n\nTomp, Tomp, Tomp,\nTomp-eli-Tomp, Tomp, Tomp, Tomp...\n\nNär cidern äntligen är klar\nså ska den buteljeras\noch etiketten sättas på,\nkaspsylen appliceras.\nOch har du tur så kan du få\nför herregud, den säljer så.\nDe länsar butiken och stoppar trafiken,\nför kön den går ända till Luleå."
+			"content": "Har ni hört, det finns en dryck\nsom görs på musterier.\nDen kan smaka sött och torrt\noch fyller skafferier.\nÄpple, päron, lime och bär,\nja, allt som ciderns frukter är.\nDe ligger och jäser och puttrar och fräser\noch skapar i tunnan en kärleksaffär.\n\nTomp, Tomp, Tomp,\nTomp-eli-Tomp, Tomp, Tomp, Tomp...\n\nNär cidern äntligen är klar\nså ska den buteljeras\noch etiketten sättas på,\nkaspsylen appliceras.\nOch har du tur så kan du få\nför herregud, den säljer så.\nDe länsar butiken och stoppar trafiken,\nför kön den går ända till Luleå.",
+			"author": "Strängteoretiquerna, IT (KTH, 2015)"
 		},
 		{
 			"id": 25,
 			"title": "Vi tar en enkel liten sång",
-			"author": "Strängteoretiquerna, 2015",
 			"melody": "Med en enkel tulipan",
 			"composer": "Jules Sylvain och Sven Paddock",
 			"tags": ["gasque", "swe"],
-			"content": "Vi tar en enkel liten sång\nmen den får ej bli så lång,\nvi har så bråttom, vi har så bråttom\natt fatta glaset.\n\nVi alla titlar har slängt bort\nför det ska inte bli torrt,\nty i kväll ska vi ha det trevligt\nuppå kalaset.\nTjo-hej!"
+			"content": "Vi tar en enkel liten sång\nmen den får ej bli så lång,\nvi har så bråttom, vi har så bråttom\natt fatta glaset.\n\nVi alla titlar har slängt bort\nför det ska inte bli torrt,\nty i kväll ska vi ha det trevligt\nuppå kalaset.\nTjo-hej!",
+			"author": "Strängteoretiquerna, IT (KTH, 2015)"
 		},
 		{
 			"id": 26,
 			"title": "Treo-comp",
-			"author": "Lundakarnevalen, 1986",
 			"melody": "Längtan till landet",
 			"composer": "Otto Lindblad",
 			"tags": ["gasque", "swe"],
-			"content": "Morgonstund med smak av döda bävrar,\nfrukostmorgonen är över oss.\nHur vi stretar, hur vi alla vägrar,\nså går solen likt förbannat opp.\n\nSnart är dagen här med hemska plågor\nhuvudvärk och ångest, elände men\ndet finns faktiskt ett glas som dig kan rädda:\nTreo-comp, vår frälsare och vän!"
+			"content": "Morgonstund med smak av döda bävrar,\nfrukostmorgonen är över oss.\nHur vi stretar, hur vi alla vägrar,\nså går solen likt förbannat opp.\n\nSnart är dagen här med hemska plågor\nhuvudvärk och ångest, elände men\ndet finns faktiskt ett glas som dig kan rädda:\nTreo-comp, vår frälsare och vän!",
+			"author": "(Lundakarnevalen, 1986)"
 		},
 		{
 			"id": 27,
@@ -239,11 +239,11 @@
 		{
 			"id": 29,
 			"title": "Vit vecka",
-			"author": "Sångarstriden Lund, 1992",
 			"melody": "White Christmas",
 			"composer": "Irving Berlin",
 			"tags": ["gasque", "swe"],
-			"content": "Jag drömmer om en vit vecka,\nsju dagar utan alkohol.\nTänk att bara skåla,\ni juice och cola\noch sedan minnas allt man gjort.\n\nJag drömmer om en vit vecka,\ndet finns en gräns för vad jag tål.\nJag vill inte dricka\nmer sprit!\nSå låt nästa vecka vara vit."
+			"content": "Jag drömmer om en vit vecka,\nsju dagar utan alkohol.\nTänk att bara skåla,\ni juice och cola\noch sedan minnas allt man gjort.\n\nJag drömmer om en vit vecka,\ndet finns en gräns för vad jag tål.\nJag vill inte dricka\nmer sprit!\nSå låt nästa vecka vara vit.",
+			"author": "(Sångarstriden, Lund, 1992)"
 		},
 		{
 			"id": 30,
@@ -256,10 +256,10 @@
 		{
 			"id": 154,
 			"title": "Viking Raiders",
-			"author": "Samuel Larsson (2020)",
 			"melody": "Spanish Ladies",
 			"tags": ["gasque", "eng"],
-			"content": "Farewell and adieu to you danish ladies\nFarewell and adieu to you lovely Danes\nFor we’re under orders to sail off to England\nWe hope in a short time to see you again\n\nWe’ll rant and we’ll roar like true viking raiders\nWe’ll plunder the shores along the north sea\nUntil we strike soundings in the channel o’ England\nFrom Valland to London ‘tis forty-five leagues\n\nWe hove our ship to, with the wind from sou’west, crew.\nWe hove our ship to, deep soundings to take.\n‘Twas twenty-one fathoms, with a murky mud bottom\nAnd bore right away, crew, and up river did make.\n\nWe’ll rant and we’ll roar...\n\nWe pull out our ships, gettin’ hold of our weapons.\nWe pull out our ships, preparing to raid.\nOur sights set on London, to get all of ’er gold.\nWhen we find the old city, we leave her in flames.\n\nWe’ll rant and we’ll roar...\n\nNow let every man drink off his full bumper\nAnd let every man drink off his full glass\nWe’ll drink and be jolly and drown melancholy\nHere’s to the health of each true-hearted lass\n\nWe’ll rant and we’ll roar..."
+			"content": "Farewell and adieu to you danish ladies\nFarewell and adieu to you lovely Danes\nFor we’re under orders to sail off to England\nWe hope in a short time to see you again\n\nWe’ll rant and we’ll roar like true viking raiders\nWe’ll plunder the shores along the north sea\nUntil we strike soundings in the channel o’ England\nFrom Valland to London ‘tis forty-five leagues\n\nWe hove our ship to, with the wind from sou’west, crew.\nWe hove our ship to, deep soundings to take.\n‘Twas twenty-one fathoms, with a murky mud bottom\nAnd bore right away, crew, and up river did make.\n\nWe’ll rant and we’ll roar...\n\nWe pull out our ships, gettin’ hold of our weapons.\nWe pull out our ships, preparing to raid.\nOur sights set on London, to get all of ’er gold.\nWhen we find the old city, we leave her in flames.\n\nWe’ll rant and we’ll roar...\n\nNow let every man drink off his full bumper\nAnd let every man drink off his full glass\nWe’ll drink and be jolly and drown melancholy\nHere’s to the health of each true-hearted lass\n\nWe’ll rant and we’ll roar...",
+			"author": "Samuel Larsson, IT (KTH, 2020)"
 		},
 		{
 			"id": 31,
@@ -366,11 +366,11 @@
 		{
 			"id": 44,
 			"title": "Öppna en öhl",
-			"author": "Carl Brengesjö, 2013",
 			"melody": "Öppna din dörr",
 			"composer": "Tommy Nilsson",
 			"tags": ["beer", "swe"],
-			"content": "Den första gång jag öppna en\noch kände hur den svalka' sen.\nBort föll allting jag trott var ballt\nkvar stod jäst, humle, liksom malt.\n\nDen var så vacker då -\nkondenstäckt, blank och ljuv som få!\nOch hjärtat slår ett slag för varje klunk jag tar.\n\nÖppna en öhl och säg om du vill ha den här.\nSäg om du i ovven bär med dig en återställare?\nOch jag ska dricka min öhl, insupa varje maltarom.\nDricka i en källare eller på en balkong.\nÖppna en öhl.\n\nHemsökte mig i fantasin, inspirera all möjlig drycksmani.\nEn whisky rökig, en korkad rom,\nalla dess sorter lagrat som.\n\nEn brygd man ömt förtär.\nSom värmer, visar vem man är.\nOch hjärtat slår ett slag för varje klunk som tas.\n\nÖppna en öhl och säg om den ej gyllene är.\nSäg att du i ovven bär med dig en återställare?\nOch du ska dricka din öhl, insupa varje maltarom.\nLeva helt för jäsningens alla gyllene svall.\nSå öppna din öhl."
+			"content": "Den första gång jag öppna en\noch kände hur den svalka' sen.\nBort föll allting jag trott var ballt\nkvar stod jäst, humle, liksom malt.\n\nDen var så vacker då -\nkondenstäckt, blank och ljuv som få!\nOch hjärtat slår ett slag för varje klunk jag tar.\n\nÖppna en öhl och säg om du vill ha den här.\nSäg om du i ovven bär med dig en återställare?\nOch jag ska dricka min öhl, insupa varje maltarom.\nDricka i en källare eller på en balkong.\nÖppna en öhl.\n\nHemsökte mig i fantasin, inspirera all möjlig drycksmani.\nEn whisky rökig, en korkad rom,\nalla dess sorter lagrat som.\n\nEn brygd man ömt förtär.\nSom värmer, visar vem man är.\nOch hjärtat slår ett slag för varje klunk som tas.\n\nÖppna en öhl och säg om den ej gyllene är.\nSäg att du i ovven bär med dig en återställare?\nOch du ska dricka din öhl, insupa varje maltarom.\nLeva helt för jäsningens alla gyllene svall.\nSå öppna din öhl.",
+			"author": "Carl Brengesjö (KTH, 2013)"
 		},
 		{
 			"id": 45,
@@ -405,11 +405,11 @@
 		{
 			"id": 49,
 			"title": "Elysisk längtan",
-			"author": "Sångarstriden Lund, 1968",
 			"melody": "An die Freude (Ode to Joy)",
 			"composer": "Ludwig van Beethoven",
 			"tags": ["wine", "swe"],
-			"content": "Aftonrodnan svalka sprider,\nskymningen sig sänker fin,\noch likt dimridåer sprider,\ndoften av det rena vin.\n\n//: Låt det hjälpa mig till att segla\nrakt in i rusets röda tröst.\nNatten flyr på gryningsvingar,\nvärmen flammar i mitt bröst. ://"
+			"content": "Aftonrodnan svalka sprider,\nskymningen sig sänker fin,\noch likt dimridåer sprider,\ndoften av det rena vin.\n\n//: Låt det hjälpa mig till att segla\nrakt in i rusets röda tröst.\nNatten flyr på gryningsvingar,\nvärmen flammar i mitt bröst. ://",
+			"author": "(Sångarstriden, Lund, 1968)"
 		},
 		{
 			"id": 50,
@@ -453,10 +453,10 @@
 		{
 			"id": 55,
 			"title": "Längtan till landet",
-			"author": "Herman Sätherberg och Otto Lindblad",
 			"composer": "Herman Sätherberg och Otto Lindblad",
 			"tags": ["wine", "swe"],
-			"content": "Vintern rasat ut bland våra fjällar,\ndrivans blommor smälta ned och dö.\nHimlen ler i vårens ljusa kvällar,\nsolen kysser liv i skog och sjö.\nSnart är sommarn här i purpurvågor,\nguldbelagda, azurskiftande,\nligga ängarne i dagens lågor,\noch i lunden dansa källorne.\n\nJa, jag kommer! Hälsen glada vindar,\nut till landet, ut till fåglarne,\natt jag älskar dem, till björk och lindar,\nsjö och berg jag vill dem återse.\nSe dem än som i min barndoms stunder,\nfölja bäckens dans till klarnad sjö.\nTrastens sång i furuskogens lunder,\nvattenfågelns lek kring fjärd och ö."
+			"content": "Vintern rasat ut bland våra fjällar,\ndrivans blommor smälta ned och dö.\nHimlen ler i vårens ljusa kvällar,\nsolen kysser liv i skog och sjö.\nSnart är sommarn här i purpurvågor,\nguldbelagda, azurskiftande,\nligga ängarne i dagens lågor,\noch i lunden dansa källorne.\n\nJa, jag kommer! Hälsen glada vindar,\nut till landet, ut till fåglarne,\natt jag älskar dem, till björk och lindar,\nsjö och berg jag vill dem återse.\nSe dem än som i min barndoms stunder,\nfölja bäckens dans till klarnad sjö.\nTrastens sång i furuskogens lunder,\nvattenfågelns lek kring fjärd och ö.",
+			"author": "Herman Sätherberg och Otto Lindblad (1838)"
 		},
 		{
 			"id": 56,
@@ -468,10 +468,10 @@
 		{
 			"id": 57,
 			"title": "Tjugotre",
-			"author": "Carl Nisser, E-80",
 			"melody": "Amanda Lundbom",
 			"tags": ["snaps", "swe"],
-			"content": "Tjugotre är Bäska Droppar,\nbomfaderi, bomfaderalleralla.\nSkänker liv åt döda kroppar,\nbomfaderi, faderallanlej.\n\nSlå en sup i död mans kropp,\nbomfaderi faderallanlej, hugg i!\nSå vacklar han ur graven opp,\nbomfaderi, faderallanlej.\n\nJesus visste att de döda,\nbomfaderi, bomfaderalleralla,\nkunde väckas utan möda,\nbomfaderi, faderallanlej.\n\nBäska droppar nyttja han,\nbomfaderi faderallanlej, hugg i!\nOch Lazarus spratt till minsann,\nbomfaderi, faderallanlej."
+			"content": "Tjugotre är Bäska Droppar,\nbomfaderi, bomfaderalleralla.\nSkänker liv åt döda kroppar,\nbomfaderi, faderallanlej.\n\nSlå en sup i död mans kropp,\nbomfaderi faderallanlej, hugg i!\nSå vacklar han ur graven opp,\nbomfaderi, faderallanlej.\n\nJesus visste att de döda,\nbomfaderi, bomfaderalleralla,\nkunde väckas utan möda,\nbomfaderi, faderallanlej.\n\nBäska droppar nyttja han,\nbomfaderi faderallanlej, hugg i!\nOch Lazarus spratt till minsann,\nbomfaderi, faderallanlej.",
+			"author": "Carl Nisser, E-80 (KTH)"
 		},
 		{
 			"id": 58,
@@ -552,27 +552,27 @@
 		{
 			"id": 69,
 			"title": "Livet är härligt",
-			"author": "Chalmersspexet Katarina II, 1959",
 			"melody": "Röda kavalleriet (Polyushko-Pole)",
 			"composer": "Lev Knipper",
 			"tags": ["snaps", "swe"],
-			"content": "> Sjungs tyst:\n\nLivet är härligt!\nTavaritj, vårt liv är härligt!\nVi alla våra små bekymmer glömmer\nNär vi har fått en tår på tanden, skål!\n\nTag dig en vodka!\nTavaritj, en liten vodka!\nGlasen i botten vi tillsammans tömmer!\nDet kommer mera efter h-a-and.\n\n> Sjung högt:\n\nLivet är härligt!\nTavaritj, vårt liv är härligt!\nVi alla våra små bekymmer glömmer\nNär vi har fått en tår på tanden, skål!\n\nTag dig en vodka!\nTavaritj, en liten vodka!\nGlasen i botten vi tillsammans tömmer!\nDet kommer mera efter handen, skål!"
+			"content": "> Sjungs tyst:\n\nLivet är härligt!\nTavaritj, vårt liv är härligt!\nVi alla våra små bekymmer glömmer\nNär vi har fått en tår på tanden, skål!\n\nTag dig en vodka!\nTavaritj, en liten vodka!\nGlasen i botten vi tillsammans tömmer!\nDet kommer mera efter h-a-and.\n\n> Sjung högt:\n\nLivet är härligt!\nTavaritj, vårt liv är härligt!\nVi alla våra små bekymmer glömmer\nNär vi har fått en tår på tanden, skål!\n\nTag dig en vodka!\nTavaritj, en liten vodka!\nGlasen i botten vi tillsammans tömmer!\nDet kommer mera efter handen, skål!",
+			"author": "(Chalmersspexet Katarina II, 1959)"
 		},
 		{
 			"id": 70,
 			"title": "Vikingen",
-			"author": "Sångarstriden, Lund, 1981",
 			"melody": "When Johnny comes marching home",
 			"tags": ["snaps", "swe"],
-			"content": "En viking älskar livets vann,\nhurra, hurra!\n\nSom hastigt i hans svalg försvann,\nhurra, hurra!\n\nTill kalv, till oxe, till fisk, till fläsk,\nnär kärringar bara dricker läsk,\nja då vill alla vikingar ha en bäsk!\n\nNär bäsken småningom är slut:\nTragik, TRAGIK!\n\nDå bäres varje viking ut\nsom lik, sig lik!\n\nÅ' sen när vi vaknar vi sjunger en bit,\nså korkar vi upp Skånes Akvavit.\nSkål för alla, skål för alla, skål för alla\nvikingar som kom hit!"
+			"content": "En viking älskar livets vann,\nhurra, hurra!\n\nSom hastigt i hans svalg försvann,\nhurra, hurra!\n\nTill kalv, till oxe, till fisk, till fläsk,\nnär kärringar bara dricker läsk,\nja då vill alla vikingar ha en bäsk!\n\nNär bäsken småningom är slut:\nTragik, TRAGIK!\n\nDå bäres varje viking ut\nsom lik, sig lik!\n\nÅ' sen när vi vaknar vi sjunger en bit,\nså korkar vi upp Skånes Akvavit.\nSkål för alla, skål för alla, skål för alla\nvikingar som kom hit!",
+			"author": "E-Sektionen (Sångarstriden, Lund, 1981)"
 		},
 		{
 			"id": 71,
 			"title": "En gång däran",
-			"author": "Evert Taube",
 			"composer": "Evert Taube",
 			"tags": ["snaps", "swe"],
-			"content": "Än en gång däran bröder, än en gång däran,\nföljom den urgamla seden.\n\nIn till sista man, bröder, in till sista man,\ntrotsa vi hatet och vreden!\n\nBlankare vapen sågs aldrig i en här,\nän dessa glasen, kamrater: I gevär!\n\nÄn en gång däran, bröder,\nän en gång däran.\nSvenska hjärtans djup, här är din sup!\n\nLivet är så kort, bröder,\nlivet är så kort.\nLek det ej bort, nej var redo!\n\nKämpa mot allt torrt bröder,\nkämpa mot allt torrt.\n\nTänk på de gamle som skredo\nfram, utan tvekan i floder av champagne,\nstyrkta från början av brännvin från vårt land!\n\nKämpa mot allt torrt, bröder,\nkämpa mot allt torrt.\nSvenska hjärtans djup, här är din sup!"
+			"content": "Än en gång däran bröder, än en gång däran,\nföljom den urgamla seden.\n\nIn till sista man, bröder, in till sista man,\ntrotsa vi hatet och vreden!\n\nBlankare vapen sågs aldrig i en här,\nän dessa glasen, kamrater: I gevär!\n\nÄn en gång däran, bröder,\nän en gång däran.\nSvenska hjärtans djup, här är din sup!\n\nLivet är så kort, bröder,\nlivet är så kort.\nLek det ej bort, nej var redo!\n\nKämpa mot allt torrt bröder,\nkämpa mot allt torrt.\n\nTänk på de gamle som skredo\nfram, utan tvekan i floder av champagne,\nstyrkta från början av brännvin från vårt land!\n\nKämpa mot allt torrt, bröder,\nkämpa mot allt torrt.\nSvenska hjärtans djup, här är din sup!",
+			"author": "Evert Taube"
 		},
 		{
 			"id": 72,
@@ -621,11 +621,11 @@
 		{
 			"id": 78,
 			"title": "Gräv ur tundran",
-			"author": "Ekonomspexet Lenin, 1989",
 			"melody": "Katjuscha",
 			"composer": "Matvey Blanter",
 			"tags": ["snaps", "swe"],
-			"content": "> Sjung tyst:\n\nGräv ur tundran två dussin potäter,\nlåt dem jäsa uti fjorton dar.\n\n//: Modersmjölken för ryssar och sovjeter,\nbrännes i babusjkans samovar. ://\n\nKyl sen drycken i sibiriens tjäle,\ntappa upp på immiga små glas.\n\n> Sjung högt:\n\nHöj sen glasen för fosterlandets välgång, HEJ!\n\nSjung \"na zdrowie\" med en mäktig\nbas, bas, bas, bas!\n\nHöj sen glasen för fosterlandets välgång,\nsjung \"na zdrowie\", låt glasen gå i kras!\n\n> Krossa eller släng nubbeglaset efter skålen, dock endast plastglas.\n> Vid glasglas sjung \"låt glasen vara kvar\"."
+			"content": "> Sjung tyst:\n\nGräv ur tundran två dussin potäter,\nlåt dem jäsa uti fjorton dar.\n\n//: Modersmjölken för ryssar och sovjeter,\nbrännes i babusjkans samovar. ://\n\nKyl sen drycken i sibiriens tjäle,\ntappa upp på immiga små glas.\n\n> Sjung högt:\n\nHöj sen glasen för fosterlandets välgång, HEJ!\n\nSjung \"na zdrowie\" med en mäktig\nbas, bas, bas, bas!\n\nHöj sen glasen för fosterlandets välgång,\nsjung \"na zdrowie\", låt glasen gå i kras!\n\n> Krossa eller släng nubbeglaset efter skålen, dock endast plastglas.\n> Vid glasglas sjung \"låt glasen vara kvar\".",
+			"author": "(Ekonomspexet Lenin, Stockholms universitet, 1989)"
 		},
 		{
 			"id": 79,
@@ -660,53 +660,53 @@
 		{
 			"id": 83,
 			"title": "Häv, häv detta glas",
-			"author": "Erik Rålenius",
 			"melody": "Bä, bä vita lamm",
 			"composer": "Alice Tegnér",
 			"tags": ["snaps", "swe"],
-			"content": "Häv, häv detta glas, nu är det kalas.\nNä, nä, vet du va', jag ska inget ha'\nFör om jag dricker opp,\noch inte säger stopp,\nså slutar jag nog som ett minne blott."
+			"content": "Häv, häv detta glas, nu är det kalas.\nNä, nä, vet du va', jag ska inget ha'\nFör om jag dricker opp,\noch inte säger stopp,\nså slutar jag nog som ett minne blott.",
+			"author": "Erik Rålenius, IT (KTH)"
 		},
 		{
 			"id": 84,
 			"title": "Spritbolaget",
-			"author": "Göran Svensson, Sångarstriden Lund, 1989",
 			"melody": "Du käre lille snickerboa",
 			"composer": "Georg Riedel",
 			"tags": ["snaps", "swe"],
-			"content": "Till spritbolaget ränner jag\noch bankar på dess port.\nJag vill ha nåt som bränner bra\nOch gör mig skitfull fort.\nExpediten sade \"Go'dag,\nHur gammal kan min herre va?\"\nHar du nåt leg, ditt fula drägg?\nKom hit igen när du fått skägg!\n\nNej, detta var ju inte bra,\nJag ska bli full ikväll.\nDå plötsligt en idé jag fick -\ndom har ju sprit på Shell!\nMånga flaskor stod där på rad,\nSå nu kan jag bli full och glad.\nDen röda drycken åkte ner,\nnu kan jag inte se nåt mer."
+			"content": "Till spritbolaget ränner jag\noch bankar på dess port.\nJag vill ha nåt som bränner bra\nOch gör mig skitfull fort.\nExpediten sade \"Go'dag,\nHur gammal kan min herre va?\"\nHar du nåt leg, ditt fula drägg?\nKom hit igen när du fått skägg!\n\nNej, detta var ju inte bra,\nJag ska bli full ikväll.\nDå plötsligt en idé jag fick -\ndom har ju sprit på Shell!\nMånga flaskor stod där på rad,\nSå nu kan jag bli full och glad.\nDen röda drycken åkte ner,\nnu kan jag inte se nåt mer.",
+			"author": "Göran Svensson (Sångarstriden, Lund, 1989)"
 		},
 		{
 			"id": 85,
 			"title": "Rackaren",
-			"author": "Kårspexet Munken, 1983",
 			"melody": "Hamburger Ebb und Fluth",
 			"composer": "Georg Philipp Telemann",
 			"tags": ["snaps", "swe"],
-			"content": "Nu tar vi den, vår bäste vän, nu tar vi den lille rackaren.\nNu tar vi den, och ännu en, och livet blir glatt igen.\nNär tålamodet tryter,\nkan varenda bagatell bli tjat och gnat och gnäll.\nMen strunt i små dispyter,\nnu när vi får ta lille rackaren!"
+			"content": "Nu tar vi den, vår bäste vän, nu tar vi den lille rackaren.\nNu tar vi den, och ännu en, och livet blir glatt igen.\nNär tålamodet tryter,\nkan varenda bagatell bli tjat och gnat och gnäll.\nMen strunt i små dispyter,\nnu när vi får ta lille rackaren!",
+			"author": "(Kårspexet Munken, KTH, 1983)"
 		},
 		{
 			"id": 86,
 			"title": "Ganska nykter",
-			"author": "Strängteoretiquerna, 2015",
 			"melody": "Vi äro musikanter",
 			"tags": ["snaps", "swe"],
-			"content": "Jag var ganska nykter när jag nyss kom hit,\nmen nu ska jag dricka ädel akvavit.\nOch så fort jag fått en nubbe\nblir jag som en sprattelgubbe.\nJa, av nubbar får man härlig livsaptit!"
+			"content": "Jag var ganska nykter när jag nyss kom hit,\nmen nu ska jag dricka ädel akvavit.\nOch så fort jag fått en nubbe\nblir jag som en sprattelgubbe.\nJa, av nubbar får man härlig livsaptit!",
+			"author": "Strängteoretiquerna, IT (KTH, 2015)"
 		},
 		{
 			"id": 87,
 			"title": "Hyllningsvisa till Absinthen",
-			"author": "Sing-Sing Singers, 2000",
 			"melody": "O come all ye faithful",
 			"tags": ["snaps", "swe"],
-			"content": "Var är absinten,\nillgrön liksom minten,\nsom skänker galenskap åt var teknolog?\n\n(Vi) är för banala, nästan helt normala.\nJa, vi vill bli unika, ja rent magnifika,\nhelt enkelt gudalika och värda en skål!\n\nHär är absinten,\nillgrön liksom minten\nsom ger oss stirrig blick och rufsigt hår.\n\nDessutom kindfärg liksom August Strindberg.\nFör att bli kreativa har vi blitt addiktiva,\nsnart blir vi högaktiva; vi tar oss en tår!"
+			"content": "Var är absinten,\nillgrön liksom minten,\nsom skänker galenskap åt var teknolog?\n\n(Vi) är för banala, nästan helt normala.\nJa, vi vill bli unika, ja rent magnifika,\nhelt enkelt gudalika och värda en skål!\n\nHär är absinten,\nillgrön liksom minten\nsom ger oss stirrig blick och rufsigt hår.\n\nDessutom kindfärg liksom August Strindberg.\nFör att bli kreativa har vi blitt addiktiva,\nsnart blir vi högaktiva; vi tar oss en tår!",
+			"author": "Sing-Sing Singers (KTH, 2000)"
 		},
 		{
 			"id": 88,
 			"title": "Man kan dricka vatten",
-			"author": "Datas nØllespex, 1995",
 			"melody": "Vi äro musikanter",
 			"tags": ["snaps", "swe"],
-			"content": "Man kan dricka vatten, mjölk,\noch gammalt flott.\nMen vi dricker hellre\nsådant som är gott.\n\nVi kan dricka brännvin, öl och billigt vin.\nVi kan dricka olja och bensin.\n\nOch vi kan svepa islandshästar,\nmockavästar när vi festar.\nVi kan svepa svavelsyra på vår yra fest.\n\n> \"helium\" sjunges ljust.\n\nVi kan häva kvicksilver och helium.\nVi kan häva ost och vardagsrum.\n\nOch vi kan supa bomfadderalla,\nbomfadderalla, skål på er alla!\nVi kan supa andra hållet, andra hållet med."
+			"content": "Man kan dricka vatten, mjölk,\noch gammalt flott.\nMen vi dricker hellre\nsådant som är gott.\n\nVi kan dricka brännvin, öl och billigt vin.\nVi kan dricka olja och bensin.\n\nOch vi kan svepa islandshästar,\nmockavästar när vi festar.\nVi kan svepa svavelsyra på vår yra fest.\n\n> \"helium\" sjunges ljust.\n\nVi kan häva kvicksilver och helium.\nVi kan häva ost och vardagsrum.\n\nOch vi kan supa bomfadderalla,\nbomfadderalla, skål på er alla!\nVi kan supa andra hållet, andra hållet med.",
+			"author": "(Datas nØllespex, KTH, 1995)"
 		},
 		{
 			"id": 89,
@@ -719,11 +719,11 @@
 		{
 			"id": 90,
 			"title": "Ode till halvan",
-			"author": "Torgny, 1936",
 			"melody": "Längtan till landet",
 			"composer": "Otto Lindblad",
 			"tags": ["snaps", "swe"],
-			"content": "Helan rasat ner i våra magar,\nskvalpar nu på botten mol allen.\nI sin ensamhet den bittert klagar:\nDet är inte gott att vara en!\n\nSnart är halvan här, den härliga supen\nalkoholiskt ren och silverklar.\nDansar som en vårbäck genom strupen.\nHamnar? Plask! I helans boudoir!"
+			"content": "Helan rasat ner i våra magar,\nskvalpar nu på botten mol allen.\nI sin ensamhet den bittert klagar:\nDet är inte gott att vara en!\n\nSnart är halvan här, den härliga supen\nalkoholiskt ren och silverklar.\nDansar som en vårbäck genom strupen.\nHamnar? Plask! I helans boudoir!",
+			"author": "Torgny (1936)"
 		},
 		{
 			"id": 91,
@@ -735,11 +735,11 @@
 		{
 			"id": 153,
 			"title": "Regalskeppet Vasa",
-			"author": "Den Kongliga INviten",
 			"melody": "Ser du stjärnan i det blå",
 			"composer": "Leigh Harline",
 			"tags": ["snaps", "swe"],
-			"content": "Ser du skeppet i vår hamn?\nNer i Mälar'n det försvann!\nHur sjönk Vasa? Ve och fasa!\nBotten upp.\n\nFull besättning fanns ombord.\nHälften hoppa' överbord.\nSkeppet sjunka, alla drunkna!\nBotten upp!"
+			"content": "Ser du skeppet i vår hamn?\nNer i Mälar'n det försvann!\nHur sjönk Vasa? Ve och fasa!\nBotten upp.\n\nFull besättning fanns ombord.\nHälften hoppa' överbord.\nSkeppet sjunka, alla drunkna!\nBotten upp!",
+			"author": "Den Kongliga invITen (KTH)"
 		},
 		{
 			"id": 155,
@@ -780,10 +780,12 @@
 		},
 		{
 			"id": 94,
-			"title": "FESTU:s punschvisa",
-			"melody": "Tomtarnas vinternatt",
+			"title": "FestU:s punschvisa",
+			"melody": "Tomtarnas julnatt",
+			"composer": "Vilhelm Sefve-Svensson",
 			"tags": ["punsch", "swe"],
-			"content": "Punschen, punschen,\nrinner genom strupen, ner i djupen.\nBlandas, konfronteras\ndär med supen, där med supen.\nGula droppar, stärker våra kroppar,\npunsch, punsch, punsch!"
+			"content": "Punschen, punschen,\nrinner genom strupen, ner i djupen.\nBlandas, konfronteras\ndär med supen, där med supen.\nGula droppar, stärker våra kroppar,\npunsch, punsch, punsch!",
+			"author": "FestU (Chalmers)"
 		},
 		{
 			"id": 95,
@@ -865,7 +867,8 @@
 			"melody": "Öppna din dörr",
 			"composer": "Tommy Nilsson",
 			"tags": ["punsch", "swe"],
-			"content": "Den första gång jag provåt dig,\noch kände hur du kom i mig.\nDå föll allting jag trott var sant.\nNästa gång var det likadant.\n\nDu är så sliskig så,\nsom nåt jag aldrig provat på,\noch hjärtat slår ett slag,\nför var förlorad dag.\n\nJag gömde mig i fantasi.\nlångt bort från vardan's tråkeri.\nOch var gång som jag hade dig,\nså väcktes skönsång uti mig.\n\nNu står jag här idag,\nmed allt jag nånsin velat ha.\nOch hjärtat slår ett slag,\nför var förlorad dag.\n\nÖppna din kork,\noch låt mig sedan dricka dig.\nSnälla du säg inte inte nej!\nDu vet att jag vill.\n\nOch jag ska öppna din kork.\nMed punsch blir var dag till kalas.\nJag ska fylla upp mitt glas,\noch jag ska sjunga till.\nSå öppna din kork."
+			"content": "Den första gång jag provåt dig,\noch kände hur du kom i mig.\nDå föll allting jag trott var sant.\nNästa gång var det likadant.\n\nDu är så sliskig så,\nsom nåt jag aldrig provat på,\noch hjärtat slår ett slag,\nför var förlorad dag.\n\nJag gömde mig i fantasi.\nlångt bort från vardan's tråkeri.\nOch var gång som jag hade dig,\nså väcktes skönsång uti mig.\n\nNu står jag här idag,\nmed allt jag nånsin velat ha.\nOch hjärtat slår ett slag,\nför var förlorad dag.\n\nÖppna din kork,\noch låt mig sedan dricka dig.\nSnälla du säg inte inte nej!\nDu vet att jag vill.\n\nOch jag ska öppna din kork.\nMed punsch blir var dag till kalas.\nJag ska fylla upp mitt glas,\noch jag ska sjunga till.\nSå öppna din kork.",
+			"author": "P.U.S.S."
 		},
 		{
 			"id": 106,
@@ -886,11 +889,11 @@
 		{
 			"id": 108,
 			"title": "När kaffet är serverat",
-			"author": "Sångarstriden Lund, 1987",
 			"melody": "Mössens julafton",
 			"composer": "Christian Hartmann",
 			"tags": ["punsch", "swe"],
-			"content": "När kaffet är serverat,\noch maten tagit slut,\noch alla dom som blivit\nalltför fulla kastats ut.\n\nDå vill vi ha ett nytt glas\nmed något gult och kallt.\nSom höjer och förbättrar\nvår promillehalt:\n\nArrak, etanol och sackaros.\nMed salt och vatten blir\nden bästa blandning som kan fås.\nSöt och smetig, rent utav viskös.\nEn sexton, sjutton glas nånting\nså blir du medvetslös."
+			"content": "När kaffet är serverat,\noch maten tagit slut,\noch alla dom som blivit\nalltför fulla kastats ut.\n\nDå vill vi ha ett nytt glas\nmed något gult och kallt.\nSom höjer och förbättrar\nvår promillehalt:\n\nArrak, etanol och sackaros.\nMed salt och vatten blir\nden bästa blandning som kan fås.\nSöt och smetig, rent utav viskös.\nEn sexton, sjutton glas nånting\nså blir du medvetslös.",
+			"author": "(Sångarstriden, Lund, 1987)"
 		},
 		{
 			"id": 109,
@@ -902,43 +905,44 @@
 		{
 			"id": 110,
 			"title": "Härlig är punschen",
-			"author": "Juristspexet Ansgar, 2003",
 			"melody": "Nu grönskar det",
 			"tags": ["punsch", "swe"],
-			"content": "Nu blotas det i stad och land,\nnu är midsommartid.\nDräp ko, dräp häst, det är jättefest\nse blod överallt och bredvid.\nVart djur som dör ger bättre skörd,\nse där har vi ju ett svin!\nJa, dräp nu allt, dräp ko och galt\noch taxar och braxar och bin.\n\nRakt fram mot offrets gråa bord\nvi glatt vår kossa styr.\nVi slaktar Bambi och Stampe med,\nse upp så att Bamse ej flyr.\nI gyllne dryck så skålar vi\nnär vi står i det blod som vi skvätt.\nDet där det var gott, får man mer om man ber?\nJa, punsch uti blodet känns rätt."
+			"content": "Nu blotas det i stad och land,\nnu är midsommartid.\nDräp ko, dräp häst, det är jättefest\nse blod överallt och bredvid.\nVart djur som dör ger bättre skörd,\nse där har vi ju ett svin!\nJa, dräp nu allt, dräp ko och galt\noch taxar och braxar och bin.\n\nRakt fram mot offrets gråa bord\nvi glatt vår kossa styr.\nVi slaktar Bambi och Stampe med,\nse upp så att Bamse ej flyr.\nI gyllne dryck så skålar vi\nnär vi står i det blod som vi skvätt.\nDet där det var gott, får man mer om man ber?\nJa, punsch uti blodet känns rätt.",
+			"author": "(Juristspexet Ansgar, 2003)"
 		},
 		{
 			"id": 111,
 			"title": "Nu blotas det",
-			"author": "Juristspexet Ansgar, 2003",
 			"melody": "Nu grönskar det",
 			"composer": "Johann Sebastian Bac",
 			"tags": ["punsch", "swe"],
-			"content": "Nu blotas det i stad och land,\nnu är midsommartid.\nDräp ko, dräp häst, det är jättefest\nse blod överallt och bredvid.\nVart djur som dör ger bättre skörd,\nse där har vi ju ett svin!\nJa, dräp nu allt, dräp ko och galt\noch taxar och braxar och bin.\n\nRakt fram mot offrets gråa bord\nvi glatt vår kossa styr.\nVi slaktar Bambi och Stampe med,\nse upp så att Bamse ej flyr.\nI gyllne dryck så skålar vi\nnär vi står i det blod som vi skvätt.\nDet där det var gott, får man mer om man ber?\nJa, punsch uti blodet känns rätt."
+			"content": "Nu blotas det i stad och land,\nnu är midsommartid.\nDräp ko, dräp häst, det är jättefest\nse blod överallt och bredvid.\nVart djur som dör ger bättre skörd,\nse där har vi ju ett svin!\nJa, dräp nu allt, dräp ko och galt\noch taxar och braxar och bin.\n\nRakt fram mot offrets gråa bord\nvi glatt vår kossa styr.\nVi slaktar Bambi och Stampe med,\nse upp så att Bamse ej flyr.\nI gyllne dryck så skålar vi\nnär vi står i det blod som vi skvätt.\nDet där det var gott, får man mer om man ber?\nJa, punsch uti blodet känns rätt.",
+			"author": "(Juristspexet Ansgar, 2003)"
 		},
 		{
 			"id": 112,
 			"title": "Imperial punsch",
-			"author": "DKM, 2000",
 			"melody": "Imperial march, Star Wars",
 			"composer": "John Williams",
 			"tags": ["punsch", "swe"],
-			"content": "Punsch, punsch, punsch, mera punsch, mera punsch!\nPunsch, punsch, punsch, mera punsch, mera punsch!\nPunsch, punsch, punsch, mera, mera punsch!\nMer punsch, mera, mera punsch,\nmer punsch, mera punsch, punsch, punsch!"
+			"content": "Punsch, punsch, punsch, mera punsch, mera punsch!\nPunsch, punsch, punsch, mera punsch, mera punsch!\nPunsch, punsch, punsch, mera, mera punsch!\nMer punsch, mera, mera punsch,\nmer punsch, mera punsch, punsch, punsch!",
+			"author": "DKM (KTH, 2000)"
 		},
 		{
 			"id": 113,
 			"title": "Arrak",
-			"author": "André Mabande",
 			"melody": "Only you",
 			"tags": ["punsch", "swe"],
-			"content": "//: Arra ra rak, arra ra rak,\narra ra rak, arra ra rak ://\n\nPå en resa är det ej lätt,\natt beställa rätt rätt,\ntill en måltid.\n\nFrukost, middag, lunch och supé,\nnej, se det krävs något mer,\nför en skål i.\n\nPunschen passar bra till mat, min vän.\nPunschen går fint till matlagningen.\nFör min ingrediens,\ndet är punsch.\n\nPunsch punsch, punsch punsch, punsch punsch.\n\nUtomrikes är allting svårt,\ninte som hemma hos vårt.\nJag förstår ej.\n\nKan ju inte tala vårt språk,\nförsöker få dem förstå.\nMen det går ej.\n\nSka det va' så svårt få vad man beställt,\nsnart så har ju efterrätten smällt.\n//: Det enda jag vill ha, det är punsch. ://"
+			"content": "//: Arra ra rak, arra ra rak,\narra ra rak, arra ra rak ://\n\nPå en resa är det ej lätt,\natt beställa rätt rätt,\ntill en måltid.\n\nFrukost, middag, lunch och supé,\nnej, se det krävs något mer,\nför en skål i.\n\nPunschen passar bra till mat, min vän.\nPunschen går fint till matlagningen.\nFör min ingrediens,\ndet är punsch.\n\nPunsch punsch, punsch punsch, punsch punsch.\n\nUtomrikes är allting svårt,\ninte som hemma hos vårt.\nJag förstår ej.\n\nKan ju inte tala vårt språk,\nförsöker få dem förstå.\nMen det går ej.\n\nSka det va' så svårt få vad man beställt,\nsnart så har ju efterrätten smällt.\n//: Det enda jag vill ha, det är punsch. ://",
+			"author": "André Mabande"
 		},
 		{
 			"id": 152,
 			"title": "Sveriges arraktionalhymn",
 			"melody": "Du gamla, du fria",
 			"tags": ["punsch", "swe"],
-			"content": "Du ädla, du friska, du livselixir,\nmed dig vill jag mina läppar blöta.\nDen svenskaste drycken, på jorden den förblir.\n\n//: Den gyllene, den underbara söta. ://\n\nSom iskall till kaffet du ställs på vårt bord\noch även som varm till torsdagslunchen.\nJag halsar dig, lenaste dryck upp på jord.\n\n//: Ja, jag vill leva, jag vill dö iáv punschen. ://"
+			"content": "Du ädla, du friska, du livselixir,\nmed dig vill jag mina läppar blöta.\nDen svenskaste drycken, på jorden den förblir.\n\n//: Den gyllene, den underbara söta. ://\n\nSom iskall till kaffet du ställs på vårt bord\noch även som varm till torsdagslunchen.\nJag halsar dig, lenaste dryck upp på jord.\n\n//: Ja, jag vill leva, jag vill dö iáv punschen. ://",
+			"author": "(Ekonomspexet Erik XIV, Stockholms universitet, 1992)"
 		},
 		{
 			"id": 157,
@@ -951,18 +955,18 @@
 		{
 			"id": 159,
 			"title": "I Love Punsch",
-			"author": "Samuel Larsson (2020)",
 			"melody": "Java Jive",
 			"composer": "Ben Oakland and Milton Drake",
 			"tags": ["punsch", "eng"],
-			"content": "I love punsch in bites of three\nI love the punsch bottle and it loves me\nArrack and tea, makes the punsch just for me\nA shot, a shot, a shot, a shot, a shot\n\nI love punsch filling my cup\nI love the golden drops, I lick ‘em up\nNow flip the cup and punsch lovers drink up\nA shot, a shot, a shot, a shot, a shot"
+			"content": "I love punsch in bites of three\nI love the punsch bottle and it loves me\nArrack and tea, makes the punsch just for me\nA shot, a shot, a shot, a shot, a shot\n\nI love punsch filling my cup\nI love the golden drops, I lick ‘em up\nNow flip the cup and punsch lovers drink up\nA shot, a shot, a shot, a shot, a shot",
+			"author": "Samuel Larsson, IT (KTH, 2020)"
 		},
 		{
 			"id": 114,
 			"title": "Barrett's Privateers",
-			"author": "Stan Rogers",
 			"tags": ["foreign", "eng"],
-			"content": "Kan sjungas med sångledare, då sjunger alla raderna som börjar med \"\\*\", sångledaren i\növrigt solo.\nO the year was 17-78!\n\\*How I wish I was in Sherbrooke now!\nA letter of marque came from the king,\nto the scummiest vessel I'd ever seen!\n\n\\*God damn them all!\n\\*I was told we'd cruise the seas for american gold!\n\\*We'd fire no guns, shed no tears!\n\\*Now I'm a broken man on a Halifax pier,\n\\*the last of Barrett's privateers.\n\nO Elcid Barrett cried the town.\n\\*How I wish I was in Sherbrooke now!\nFor twenty brave men, all fishermen who\nwould make for him the Antelope's crew.\n\n\\*God damn them all ...\n\nThe Antelope sloop was a sickening sight.\n\\*How I wish I was in Sherbrooke now!\nShe'd a list to the port and her sails in rags\nand the cook in the scuppers\nwith the staggers and jags!\n\n\\*God damn them all ...\n\nOn the king's birthday we put to sea.\n\\*How I wish I was in Sherbrooke now!\nWe were ninety-one days to Montego Bay,\npumping like madmen all the way.\n\n\\*God damn them all ...\n\nOn 96th day we sailed again.\n\\*How I wish I was in Sherbrooke now!\nWhen a bloody great yankee hove in sight,\nwith our cracked four-pounders we made to fight.\n\n\\*God damn them all ...\n\nThe yankee lay low down with gold.\n\\*How I wish I was in Sherbrooke now!\nShe was broad and fat and loose in the stays,\nbut to catch her took the Antelope two whole days.\n\n\\*God damn them all ...\n\nThen at length we stood, two cables away.\n\\*How I wish I was in Sherbrooke now!\nOur cracked four-pounders made an awful din,\nbut with one fat ball the yank stove us in.\n\n\\*God damn them all ...\n\nThe Antelope shook and pitched on her side.\n\\*How I wish I was in Sherbrooke now!\nBarrett was smashed like a bowl of eggs,\nand the main-truck carried off both me legs.\n\n*God damn them all!\n*I was told we'd cruise the seas for american gold!\n*We'd fire no guns, shed no tears!\n*Now I'm a broken man on a Halifax pier,\n\\*the last of Barrett's privateers.\n\nNow here I lay in my 23rd year.\n\\*How I wish I was in Sherbrooke now!\nIt's been six long years since we sailed away,\nand I just made Halifax yesterday.\n\n\\*God damn them all ..."
+			"content": "Kan sjungas med sångledare, då sjunger alla raderna som börjar med \"\\*\", sångledaren i\növrigt solo.\nO the year was 17-78!\n\\*How I wish I was in Sherbrooke now!\nA letter of marque came from the king,\nto the scummiest vessel I'd ever seen!\n\n\\*God damn them all!\n\\*I was told we'd cruise the seas for american gold!\n\\*We'd fire no guns, shed no tears!\n\\*Now I'm a broken man on a Halifax pier,\n\\*the last of Barrett's privateers.\n\nO Elcid Barrett cried the town.\n\\*How I wish I was in Sherbrooke now!\nFor twenty brave men, all fishermen who\nwould make for him the Antelope's crew.\n\n\\*God damn them all ...\n\nThe Antelope sloop was a sickening sight.\n\\*How I wish I was in Sherbrooke now!\nShe'd a list to the port and her sails in rags\nand the cook in the scuppers\nwith the staggers and jags!\n\n\\*God damn them all ...\n\nOn the king's birthday we put to sea.\n\\*How I wish I was in Sherbrooke now!\nWe were ninety-one days to Montego Bay,\npumping like madmen all the way.\n\n\\*God damn them all ...\n\nOn 96th day we sailed again.\n\\*How I wish I was in Sherbrooke now!\nWhen a bloody great yankee hove in sight,\nwith our cracked four-pounders we made to fight.\n\n\\*God damn them all ...\n\nThe yankee lay low down with gold.\n\\*How I wish I was in Sherbrooke now!\nShe was broad and fat and loose in the stays,\nbut to catch her took the Antelope two whole days.\n\n\\*God damn them all ...\n\nThen at length we stood, two cables away.\n\\*How I wish I was in Sherbrooke now!\nOur cracked four-pounders made an awful din,\nbut with one fat ball the yank stove us in.\n\n\\*God damn them all ...\n\nThe Antelope shook and pitched on her side.\n\\*How I wish I was in Sherbrooke now!\nBarrett was smashed like a bowl of eggs,\nand the main-truck carried off both me legs.\n\n*God damn them all!\n*I was told we'd cruise the seas for american gold!\n*We'd fire no guns, shed no tears!\n*Now I'm a broken man on a Halifax pier,\n\\*the last of Barrett's privateers.\n\nNow here I lay in my 23rd year.\n\\*How I wish I was in Sherbrooke now!\nIt's been six long years since we sailed away,\nand I just made Halifax yesterday.\n\n\\*God damn them all ...",
+			"author": "Stan Rogers"
 		},
 		{
 			"id": 115,
@@ -998,16 +1002,17 @@
 		{
 			"id": 120,
 			"title": "My heart will go on",
-			"author": "Celine Dion",
+			"composer": "James Horner",
 			"tags": ["foreign", "eng"],
-			"content": "Every night in my dreams\nI see you, I feel you.\nThat is how I know you go on.\n\nFar across the distance\nand spaces between us\nyou have come to show you go on.\n\nNear, far, wherever you are,\nI believe that the heart does go on.\nOnce more you open the door,\nand you're here in my heart and\nmy heart will go on and on.\n\nLove can touch us one time\nand last for a lifetime.\nAnd never let go 'til we're gone.\n\nLove was when I loved you\none true time I hold to.\nIn my life we'll always go on.\n\nNear, far, wherever you are,\nI believe that the heart does go on.\nOnce more you open the door\nAnd you're here in my heart and\nmy heart will go on and on.\n\nYou're here, there's nothing I fear,\nand I know that my heart will go on.\nWe'll stay forever this way.\nYou are safe in my heart and\nmy heart will go on and on."
+			"content": "Every night in my dreams\nI see you, I feel you.\nThat is how I know you go on.\n\nFar across the distance\nand spaces between us\nyou have come to show you go on.\n\nNear, far, wherever you are,\nI believe that the heart does go on.\nOnce more you open the door,\nand you're here in my heart and\nmy heart will go on and on.\n\nLove can touch us one time\nand last for a lifetime.\nAnd never let go 'til we're gone.\n\nLove was when I loved you\none true time I hold to.\nIn my life we'll always go on.\n\nNear, far, wherever you are,\nI believe that the heart does go on.\nOnce more you open the door\nAnd you're here in my heart and\nmy heart will go on and on.\n\nYou're here, there's nothing I fear,\nand I know that my heart will go on.\nWe'll stay forever this way.\nYou are safe in my heart and\nmy heart will go on and on.",
+			"author": "Celine Dion (1997)"
 		},
 		{
 			"id": 121,
 			"title": "In the trade of jester",
-			"author": "Jauvet",
 			"tags": ["foreign", "eng"],
-			"content": "In the trade of jester,\nwe're fools that play our part.\nIn an act sworn by folklore,\nwhere the lines are made by heart.\n\nGetting gold from the nobles\nand mockin' from ye all.\nBut we drink with the greatest warriors,\nand we dance in every hall.\n\nWe travel through the country,\nwe go from town to town.\nWe're the sworn kings of jester\nbut we've never worn a crown.\n\nGetting gold ...\n\nI've never had a family,\nnor have I had a wife.\nIt's a high cost of living,\nit's the price I pay for life.\n\nGetting gold ...\n\nWe meet the fairest ladies,\nbut we never had a chance.\nSo we play our bagpipes\nas the common people dance.\n\n> \"Säckpipor\"\n\nTo die without a nickel\nis a scare for anyone.\nSo we work until our last day,\nand we die like common man.\n\nGetting gold ...\n\n> Skriven av en gycklargrupp från Norrköping och\n> därmed inte precis utländsk."
+			"content": "In the trade of jester,\nwe're fools that play our part.\nIn an act sworn by folklore,\nwhere the lines are made by heart.\n\nGetting gold from the nobles\nand mockin' from ye all.\nBut we drink with the greatest warriors,\nand we dance in every hall.\n\nWe travel through the country,\nwe go from town to town.\nWe're the sworn kings of jester\nbut we've never worn a crown.\n\nGetting gold ...\n\nI've never had a family,\nnor have I had a wife.\nIt's a high cost of living,\nit's the price I pay for life.\n\nGetting gold ...\n\nWe meet the fairest ladies,\nbut we never had a chance.\nSo we play our bagpipes\nas the common people dance.\n\n> \"Säckpipor\"\n\nTo die without a nickel\nis a scare for anyone.\nSo we work until our last day,\nand we die like common man.\n\nGetting gold ...\n\n> Skriven av en gycklargrupp från Norrköping och\n> därmed inte precis utländsk.",
+			"author": "Jauvet"
 		},
 		{
 			"id": 122,
@@ -1028,33 +1033,33 @@
 		{
 			"id": 124,
 			"title": "Unix Man",
-			"author": "Bran Morrison",
 			"melody": "Nowhere Man",
 			"composer": "John Lennon and Paul McCartney",
 			"tags": ["nerdy", "eng"],
-			"content": "He's a real UNIX Man,\nsitting in his UNIX LAN,\nmaking all his UNIX .plans\nfor nobody.\n\nKnows the blocksize from 'du'.\nCares not where /dev/null goes to.\nIsn't he a bit like you and me?\n\nUNIX Man, don't worry.\nIt's the tube that's blurry.\nUNIX Man,\nthe new kernel boots,\njust like you had planned.\n\nHe's as wise as he can be.\nPrograms in lex, yacc and C.\nUNIX Man, can you help me at all?\n\nUNIX Man, please listen.\nMy printout is missin'.\nUNIX Man,\nthe wo-o-o-orld is your 'at' command."
+			"content": "He's a real UNIX Man,\nsitting in his UNIX LAN,\nmaking all his UNIX .plans\nfor nobody.\n\nKnows the blocksize from 'du'.\nCares not where /dev/null goes to.\nIsn't he a bit like you and me?\n\nUNIX Man, don't worry.\nIt's the tube that's blurry.\nUNIX Man,\nthe new kernel boots,\njust like you had planned.\n\nHe's as wise as he can be.\nPrograms in lex, yacc and C.\nUNIX Man, can you help me at all?\n\nUNIX Man, please listen.\nMy printout is missin'.\nUNIX Man,\nthe wo-o-o-orld is your 'at' command.",
+			"author": "Bran Morrison"
 		},
 		{
 			"id": 125,
 			"title": "Man ska ha Linux",
-			"author": "Erik Rålenius",
 			"melody": "Man ska ha husvagn",
 			"composer": "Claes Eriksson",
 			"tags": ["nerdy", "swe"],
-			"content": "Jag har prövat alla operativ som finnas kan:\nWindows, OS/X, Amiga-OS, och Symbian.\nJag har klickat runt på skärmen\ntills jag drypit helt av svett\noch äntligen har jag hittat\nsystemet som är rätt:\n\nMan ska ha Linux,\ndå kan ens dator vara klen.\nMan ska ha Linux,\ndå har man lagom med problem.\nMan ska ha Linux,\noch aldrig tvingas starta om.\nMan ska ha Linux, / äger C:\n\nI många år så var jag trogen\nMicrosoft-koncernen,\noch strunta i att jag inte fick\nkompilera kerneln.\nMen så en dag sa jag till frugan,\nvänligt men bestämt:\n\"Vi skaffar oss ett nytt OS\nsom inte är ett skämt!\"\n\nMan ska ha Linux,\nsom är ett hopplock utav allt.\nMan ska ha Linux,\ndå kan man hålla huvudet kallt.\nMan ska ha Linux,\nså slipper man allt grafiskt trams.\nMan ska ha Linux,\ndå går allt som en dans.\n\nFem minuter kompilering\noch fem minuters manpage,\nfem minuter mkdir\noch fem minuter swap space,\nfem minuter bash\noch gnome och fem xorg,\nfem minuters config av ens tui-editor.\n\nMan ska ha Linux,\nom man vill vara en äkta geek.\nMan ska ha Linux,\nnär allt är gratis blir man rik.\nMan ska ha Linux,\noch slippa datahaveri.\nMan ska ha Linux,\ndå är man riktigt fri!"
+			"content": "Jag har prövat alla operativ som finnas kan:\nWindows, OS/X, Amiga-OS, och Symbian.\nJag har klickat runt på skärmen\ntills jag drypit helt av svett\noch äntligen har jag hittat\nsystemet som är rätt:\n\nMan ska ha Linux,\ndå kan ens dator vara klen.\nMan ska ha Linux,\ndå har man lagom med problem.\nMan ska ha Linux,\noch aldrig tvingas starta om.\nMan ska ha Linux, / äger C:\n\nI många år så var jag trogen\nMicrosoft-koncernen,\noch strunta i att jag inte fick\nkompilera kerneln.\nMen så en dag sa jag till frugan,\nvänligt men bestämt:\n\"Vi skaffar oss ett nytt OS\nsom inte är ett skämt!\"\n\nMan ska ha Linux,\nsom är ett hopplock utav allt.\nMan ska ha Linux,\ndå kan man hålla huvudet kallt.\nMan ska ha Linux,\nså slipper man allt grafiskt trams.\nMan ska ha Linux,\ndå går allt som en dans.\n\nFem minuter kompilering\noch fem minuters manpage,\nfem minuter mkdir\noch fem minuter swap space,\nfem minuter bash\noch gnome och fem xorg,\nfem minuters config av ens tui-editor.\n\nMan ska ha Linux,\nom man vill vara en äkta geek.\nMan ska ha Linux,\nnär allt är gratis blir man rik.\nMan ska ha Linux,\noch slippa datahaveri.\nMan ska ha Linux,\ndå är man riktigt fri!",
+			"author": "Erik Rålenius, IT (KTH)"
 		},
 		{
 			"id": 126,
 			"title": "Om Emacs",
-			"author": "Ingemar Ragnemalm",
 			"melody": "Kovan kommer, kovan går",
 			"tags": ["nerdy", "swe"],
-			"content": "Emacs är en stor koloss, tugga på, tugga på.\nVerkar aldrig komma loss, tugga på, tugga på.\nFör att flytta på ett tecken\ngår två meg i garbage-säcken.\nNer i skärmens undre rand\nstår: garbage collecting, done!\n\nVäntar på'n till min pension, tugga på, tugga på.\nEmacs gör en Sparcstation, tugga på, tugga på.\nSnabb som en ABC-80.\nHögprestanda blir så smått i\nEmacs, den ser säkert till\ningen dödtid blir förspilld!\n\nEmacs skriven är i Lisp, tugga på, tugga på.\nInget rimmar alls på Lisp, tugga på, tugga på.\nOm du in i kärnan trevar\nfinn en gnu som motorn vevar.\nDen drar Emacs runt för hand!\nKlart att det går trögt ibland!"
+			"content": "Emacs är en stor koloss, tugga på, tugga på.\nVerkar aldrig komma loss, tugga på, tugga på.\nFör att flytta på ett tecken\ngår två meg i garbage-säcken.\nNer i skärmens undre rand\nstår: garbage collecting, done!\n\nVäntar på'n till min pension, tugga på, tugga på.\nEmacs gör en Sparcstation, tugga på, tugga på.\nSnabb som en ABC-80.\nHögprestanda blir så smått i\nEmacs, den ser säkert till\ningen dödtid blir förspilld!\n\nEmacs skriven är i Lisp, tugga på, tugga på.\nInget rimmar alls på Lisp, tugga på, tugga på.\nOm du in i kärnan trevar\nfinn en gnu som motorn vevar.\nDen drar Emacs runt för hand!\nKlart att det går trögt ibland!",
+			"author": "Ingemar Ragnemalm (LiU)"
 		},
 		{
 			"id": 127,
 			"title": "Ostkaka",
-			"melody": "Dovahkin, Skyrim theme",
+			"melody": "Dovahkin (Skyrim theme)",
 			"composer": "Jeremy Soule",
 			"tags": ["nerdy", "swe"],
 			"content": "Ostkaka! Det var gott.\nPå mitt bord, klockan tolv.\nEn stor stark, diskotek.\nMarcus!\n\nFast den starke får slut på thaimat, igår!\n\nVar är din galna ding?\nSka va Simbas familj!\nVad är värst? På vårt torn.\nHan vill ha ett glas saft.\nHan förstår på ett nafs\noch du måst' in på dass!\nSkala din Aladdin!\nPå en naken dag.\n\nHA HA HA HA!\nHA HA HA HA!"
@@ -1062,132 +1067,132 @@
 		{
 			"id": 160,
 			"title": "Jag kan lära dig C",
-			"author": "Arian och Sixten (DISK KM), DISK KM:s julfest 2011",
 			"melody": "A Whole New World",
 			"composer": "Alan Menken",
 			"tags": ["nerdy", "swe"],
-			"content": "Låt mig visa dig kod\nVacker, effektiv, härlig\nSäg om du ska va ärlig,\nhar du drömt om den ibland?\n\nJag kan lära dig C\nEgen minneshantering\nPekare och funktioner\nom du kodar här med mig\n\nHello World!\nHär får vi göra som vi vill\nKoden regerar här!\nC och lär!\nKompilatorn är vår vän\nEn helt ny värld\nUtan nån jävla MDI\nInget designertjat, så underbart\nAtt koda i en helt ny värld, med dig"
+			"content": "Låt mig visa dig kod\nVacker, effektiv, härlig\nSäg om du ska va ärlig,\nhar du drömt om den ibland?\n\nJag kan lära dig C\nEgen minneshantering\nPekare och funktioner\nom du kodar här med mig\n\nHello World!\nHär får vi göra som vi vill\nKoden regerar här!\nC och lär!\nKompilatorn är vår vän\nEn helt ny värld\nUtan nån jävla MDI\nInget designertjat, så underbart\nAtt koda i en helt ny värld, med dig",
+			"author": "Arian och Sixten (DISK KM:s julfest, Stockholms universitet, 2011)"
 		},
 		{
 			"id": 161,
 			"title": "Write in C",
-			"author": "Jay Piecora, SUNY Binghamton",
 			"melody": "Let It Be",
 			"composer": "John Lennon, Paul McCartney",
 			"tags": ["nerdy", "eng"],
-			"content": "When I find my code in tons of trouble,\nfriends and colleagues come to me,\nspeaking words of wisdom: “Write in C.”\n\nAs the deadline fast approaches,\nand bugs are all that I can see,\nsomewhere, someone whispers: “Write in C.”\n\nWrite in C, write in C,\nwrite in C, oh, write in C.\nLOGO's dead and buried, write in C.\n\nI used to write a lot of FORTRAN;<\nfor science it worked flawlessly.\nTry using it for graphics! Write in C.\n\nIf you've just spent nearly 30 hours\ndebugging some assembly,\nsoon you will be glad to write in C.\n\nWrite in C, write in C,\nwrite in C, yeah, write in C.\nOnly wimps use BASIC, write in C.\n\nWrite in C, write in C,\nwrite in C, oh, write in C.\nPascal won't quite cut it, write in C.\n\nWrite in C, write in C,\nwrite in C, yeah, write in C.\nDon't even mention COBOL. Write in C."
+			"content": "When I find my code in tons of trouble,\nfriends and colleagues come to me,\nspeaking words of wisdom: “Write in C.”\n\nAs the deadline fast approaches,\nand bugs are all that I can see,\nsomewhere, someone whispers: “Write in C.”\n\nWrite in C, write in C,\nwrite in C, oh, write in C.\nLOGO's dead and buried, write in C.\n\nI used to write a lot of FORTRAN;<\nfor science it worked flawlessly.\nTry using it for graphics! Write in C.\n\nIf you've just spent nearly 30 hours\ndebugging some assembly,\nsoon you will be glad to write in C.\n\nWrite in C, write in C,\nwrite in C, yeah, write in C.\nOnly wimps use BASIC, write in C.\n\nWrite in C, write in C,\nwrite in C, oh, write in C.\nPascal won't quite cut it, write in C.\n\nWrite in C, write in C,\nwrite in C, yeah, write in C.\nDon't even mention COBOL. Write in C.",
+			"author": "Jay Piecora (SUNY Binghamton)"
 		},
 		{
 			"id": 128,
 			"title": "Pop opp i topp",
-			"author": "Thore Skogman, 1965",
 			"tags": ["esoteric", "swe"],
-			"content": "Pop opp i topp, det är toppen i år!\nPop, pop, pop opp i topp-opp!\nPop opp i topp så att pulsarna slår,\npop opp i topp-opp!\n\nPop opp i topp, melodi-radio-dax,\npop, pop, pop opp i topp-opp!\nPop opp i topp och man smälter som vax,\npop opp i topp-opp!\n\nVärlden är full av elektriska 'jänger,\npop, pop, pop opp i topp-opp!\nAlla har drabbats av samma refräng,\npop opp i topp-opp!\n\nOch allting ska göras med\nWatt och med Volt,\npop, pop, pop opp i topp-opp!\nOch ungarna börjar när de går i golv,\npop opp i topp-opp!\n\nPop opp i topp, det är toppen i år...\n\nJa, mamma och pappa får inte ta ton,\npop, pop, pop opp i topp-opp!\nNej, de har avgått med ålderspension,\npop opp i topp-opp!\n\nKanske de vill, men de kan ej förstå,\npop, pop, pop opp i topp-opp!\nDeras musik den är gammal och grå,\npop opp i topp-opp!\n\nPop opp i topp, det är toppen i år...\n\nAllting ska gå med elektricitet,\npop, pop, pop opp i topp-opp!\nDet känns som man var på en annan planet,\npop opp i topp-opp!\n\nMen rätt som man spelar\nså går det en propp,\npop, pop, pop opp i topp-opp!\nStrömmen blir bruten och då blir det stopp,\npop, pop, pop i topp-opp,\npop, pop, pop i topp-opp!"
+			"content": "Pop opp i topp, det är toppen i år!\nPop, pop, pop opp i topp-opp!\nPop opp i topp så att pulsarna slår,\npop opp i topp-opp!\n\nPop opp i topp, melodi-radio-dax,\npop, pop, pop opp i topp-opp!\nPop opp i topp och man smälter som vax,\npop opp i topp-opp!\n\nVärlden är full av elektriska 'jänger,\npop, pop, pop opp i topp-opp!\nAlla har drabbats av samma refräng,\npop opp i topp-opp!\n\nOch allting ska göras med\nWatt och med Volt,\npop, pop, pop opp i topp-opp!\nOch ungarna börjar när de går i golv,\npop opp i topp-opp!\n\nPop opp i topp, det är toppen i år...\n\nJa, mamma och pappa får inte ta ton,\npop, pop, pop opp i topp-opp!\nNej, de har avgått med ålderspension,\npop opp i topp-opp!\n\nKanske de vill, men de kan ej förstå,\npop, pop, pop opp i topp-opp!\nDeras musik den är gammal och grå,\npop opp i topp-opp!\n\nPop opp i topp, det är toppen i år...\n\nAllting ska gå med elektricitet,\npop, pop, pop opp i topp-opp!\nDet känns som man var på en annan planet,\npop opp i topp-opp!\n\nMen rätt som man spelar\nså går det en propp,\npop, pop, pop opp i topp-opp!\nStrömmen blir bruten och då blir det stopp,\npop, pop, pop i topp-opp,\npop, pop, pop i topp-opp!",
+			"author": "Thore Skogman (1965)"
 		},
 		{
 			"id": 129,
 			"title": "PRAOs visa",
-			"author": "Niklas Söderlund och Wilhelm Svenselius",
 			"melody": "När månen vandrar",
 			"tags": ["esoteric", "swe"],
-			"content": "Nu har vi tvingats att skriva spex,\nmen idéerna tryter.\nVi har fått leva på luft och kex,\noch klubbmästaren ryter:\n\"Era drägg, ni e' inge bra!\"\nOch praoen svarte:\n\"Jag vill bli invald,\nom blott jag får, om blott jag får.\""
+			"content": "Nu har vi tvingats att skriva spex,\nmen idéerna tryter.\nVi har fått leva på luft och kex,\noch klubbmästaren ryter:\n\"Era drägg, ni e' inge bra!\"\nOch praoen svarte:\n\"Jag vill bli invald,\nom blott jag får, om blott jag får.\"",
+			"author": "Niklas Söderlund och Wilhelm Svenselius, IT-03 (KTH)"
 		},
 		{
 			"id": 130,
 			"title": "Vår flygpilot",
-			"author": "Dain Nilsson",
 			"melody": "Oh Tannenbaum",
 			"tags": ["esoteric", "swe"],
-			"content": "//: Vår flygpilot, vår flygpilot,\nfår inte va nån' idiot. ://\nFör om han är en idiot,\nså kan vi bli en hög med skrot.\nVår flygpilot, vår flygpilot,\nfår inte va nån' idiot."
+			"content": "//: Vår flygpilot, vår flygpilot,\nfår inte va nån' idiot. ://\nFör om han är en idiot,\nså kan vi bli en hög med skrot.\nVår flygpilot, vår flygpilot,\nfår inte va nån' idiot.",
+			"author": "Dain Nilsson, IT-04 (KTH)"
 		},
 		{
 			"id": 131,
 			"title": "Farväl till IT-sektionen",
-			"author": "Dain Nilsson och Erik Rålenius",
 			"melody": "Uti vår hage",
 			"tags": ["esoteric", "swe"],
-			"content": "IT-sektionen den finns inte mer,\nvi minns den väl.\nTillbaks till det gamla,\nvi bönar och ber.\nMan ska kunna skriva Mozart,\nhela IP har blivit kolsvart.\nHujeda mina vänner,\ndet var bättre förr!\n\nIT-sektionen den finns inte mer,\nNULL-pekare!\nKlubbmästeriet hur vi saknar er.\nKräftskiva och annat festligt,\nvi kan räkna ut betygssnitt.\nNu har ni bokstäver, va' fan är det?\n\nIN-sektionen en framtid vi ser,\nett helvete!\nOch tjejer i skolan, ni blir fler och fler!\nOch ME får stå i baren,\noch detta var inte planen,\noch vem fan är Rönngren?\nDet var bättre förr!"
+			"content": "IT-sektionen den finns inte mer,\nvi minns den väl.\nTillbaks till det gamla,\nvi bönar och ber.\nMan ska kunna skriva Mozart,\nhela IP har blivit kolsvart.\nHujeda mina vänner,\ndet var bättre förr!\n\nIT-sektionen den finns inte mer,\nNULL-pekare!\nKlubbmästeriet hur vi saknar er.\nKräftskiva och annat festligt,\nvi kan räkna ut betygssnitt.\nNu har ni bokstäver, va' fan är det?\n\nIN-sektionen en framtid vi ser,\nett helvete!\nOch tjejer i skolan, ni blir fler och fler!\nOch ME får stå i baren,\noch detta var inte planen,\noch vem fan är Rönngren?\nDet var bättre förr!",
+			"author": "Dain Nilsson, IT-04, och Erik Rålenius, IT (KTH)"
 		},
 		{
 			"id": 132,
 			"title": "IN-sektionen",
-			"author": "Dain Nilsson och Erik Rålenius",
 			"melody": "Rysslands nationalsång",
 			"composer": "Aleksander Aleksandrov",
 			"tags": ["esoteric", "swe"],
-			"content": "IN-sektionen, nya unionen.\nAlla är vänner och gör allt ihop.\nMan skålar och skrattar\noch vaktis han krattar.\nAlla kan dela på allt som är bra.\n\nIN-sektionen, värsta expansionen.\nNu är den kommen, framtiden är här.\nVi fattar våra händer\noch ser vad som händer.\nIN-sektionen lös alla problem!"
+			"content": "IN-sektionen, nya unionen.\nAlla är vänner och gör allt ihop.\nMan skålar och skrattar\noch vaktis han krattar.\nAlla kan dela på allt som är bra.\n\nIN-sektionen, värsta expansionen.\nNu är den kommen, framtiden är här.\nVi fattar våra händer\noch ser vad som händer.\nIN-sektionen lös alla problem!",
+			"author": "Dain Nilsson, IT-04, och Erik Rålenius, IT (KTH)"
 		},
 		{
 			"id": 133,
 			"title": "Faddersången 2001",
-			"author": "Kjell Ahlström",
 			"melody": "SJ, SJ, gamle vän",
 			"composer": "Elizabeth Cotten",
 			"tags": ["esoteric", "swe"],
-			"content": "Nu ska vi till Barnens Ö,\nfesta, skoja, tills vi dö!\nMycket kul för billig peng\nmed vårat faddergäng.\n\nnØllan dum och vilsen är,\nalla faddrar nØllan lär,\nhur man ingen tenta kör\noch att man gasuqa bör.\n\nNär vi lärt dem allt vi kan,\nuppgraderas hon och han.\nTill en etta ruskigt fort\nmed lap och wavelankort!\n\nKista kallas vår nation,\ntydlig gräns är dess station.\nBron den utgör gränsens strand\ntill farligt ghettoland.\n\n> Den sista versen delades ut på separata lappar i bussen och skall därför betraktas\n> som inofficiell."
+			"content": "Nu ska vi till Barnens Ö,\nfesta, skoja, tills vi dö!\nMycket kul för billig peng\nmed vårat faddergäng.\n\nnØllan dum och vilsen är,\nalla faddrar nØllan lär,\nhur man ingen tenta kör\noch att man gasuqa bör.\n\nNär vi lärt dem allt vi kan,\nuppgraderas hon och han.\nTill en etta ruskigt fort\nmed lap och wavelankort!\n\nKista kallas vår nation,\ntydlig gräns är dess station.\nBron den utgör gränsens strand\ntill farligt ghettoland.\n\n> Den sista versen delades ut på separata lappar i bussen och skall därför betraktas som inofficiell.",
+			"author": "Kjell Ahlström (KTH, 2001)"
 		},
 		{
 			"id": 134,
 			"title": "Läs inte på Handels",
-			"author": "Alex Ellgren och Oscar Frick",
 			"tags": ["esoteric", "swe"],
-			"content": "Sångledaren läser raderna som startar med \"\\*\"\nStudenter se det är som så,\njag är nyss fyllda 18 år.\nSå vilken skola är av bästa klass?\nJag vill inte ses som kass!\n\nLäs inte på Komvux, nej nej!\nLäs inte på Handels, nej nej!\nLäs inte på Chalmers,\nnej nej nej nej nej nej!\nLäs nåt som du har glädje av!\n\nSkolan ska' va riktigt bra,\ndet bästa är det som jag vill ha.\nKanske du minns hur du kände dig,\nkåren, vill ni hjälpa mig?\n\nLäs inte på Komvux...\n\nInget råd jag ännu fått,\nhittils endast dank jag slått,\nså hjälp mig nu den kära kår,\nvarför KTH?\n\nLäs inte på Komvux...\n\n\\*invITen?\nDe är grannast att se på!\n\n\\*Vår dräkt då?\nDen får en att må!\n\n\\*Vår logga?\nDen inger respekt!\n\n\\*I Kista!\nInte direkt low-tech!\n\n\\*Ljus framtid?\nDet blir inte ljusare än så!\n\n\\*Ej Chalmers?\nDär kan man ju rakt inte gå!\n\nLäs inte på Komvux...\n\nJag är trött på trams utan en spänn,\nge mig pappren till CSN!\nJag har pluggat och slitit i många år.\nNu till KTH jag går!"
+			"content": "Sångledaren läser raderna som startar med \"\\*\"\nStudenter se det är som så,\njag är nyss fyllda 18 år.\nSå vilken skola är av bästa klass?\nJag vill inte ses som kass!\n\nLäs inte på Komvux, nej nej!\nLäs inte på Handels, nej nej!\nLäs inte på Chalmers,\nnej nej nej nej nej nej!\nLäs nåt som du har glädje av!\n\nSkolan ska' va riktigt bra,\ndet bästa är det som jag vill ha.\nKanske du minns hur du kände dig,\nkåren, vill ni hjälpa mig?\n\nLäs inte på Komvux...\n\nInget råd jag ännu fått,\nhittils endast dank jag slått,\nså hjälp mig nu den kära kår,\nvarför KTH?\n\nLäs inte på Komvux...\n\n\\*invITen?\nDe är grannast att se på!\n\n\\*Vår dräkt då?\nDen får en att må!\n\n\\*Vår logga?\nDen inger respekt!\n\n\\*I Kista!\nInte direkt low-tech!\n\n\\*Ljus framtid?\nDet blir inte ljusare än så!\n\n\\*Ej Chalmers?\nDär kan man ju rakt inte gå!\n\nLäs inte på Komvux...\n\nJag är trött på trams utan en spänn,\nge mig pappren till CSN!\nJag har pluggat och slitit i många år.\nNu till KTH jag går!",
+			"author": "Alex Ellgren, ME-07, och Oscar Frick, ME-07 (KTH)"
 		},
 		{
 			"id": 135,
 			"title": "Satansvisan",
-			"author": "J. Strauss, Strauss ex Machina",
 			"melody": "Staffan var en stalledräng",
 			"tags": ["esoteric", "swe"],
-			"content": "Algot är en ockultist\nPå onda böcker samla\nEn esoterisk nihilist\nSom offra till Dom Gamla\nIngen Dagon synes än\nStjärnorna står fel, min vän, på himlen\n\nRosor är röda, violer blå\nKlös och slå, hej och hå\nZombies är döda men traskar ändå\nHasar på rutten tå\nHjärnorna de smakar så härligt\nLikstelheten knakar helt förfärligt\nKöttet rått och skinnet grått\nDe fälls av ett huvudskott\n\nEn elak man från Helsingfors\nHan åkallade Satan\nMed blåvitt inverterat kors\nMen han var för lat, han\nStackars lille djävulspräst\nFinska Necronomicon är svårläst\n\nElof var en excorcist\nIfall att du blir besatt\nKrucifix mot Antikrist\nOnda skratt i julenatt\nEn gång var den besatte för galen\nElof läste fel i ritualen\nPlötsligt hördes det ett dån\nHan svaldes av en demon\n\nBirger är en lykantrop\nHan ylar som en fåne\nVresigt pälsklädd, snar till dråp\nAllt för den fulla måne\nDräpes lätt med silverspett\nAkta dig för varulvsbett, din jävel\n\nGillar du att äta lik?\nOnd bråd död, ditt levebröd\nDå är varje kyrkogård ett fik\nIngen tid för griftefrid\nOfferbål i natten vi tända\nKom och låt oss gravarna skända\nVarje jul i detta land\nEn kyrka blir satt i brand"
+			"content": "Algot är en ockultist\nPå onda böcker samla\nEn esoterisk nihilist\nSom offra till Dom Gamla\nIngen Dagon synes än\nStjärnorna står fel, min vän, på himlen\n\nRosor är röda, violer blå\nKlös och slå, hej och hå\nZombies är döda men traskar ändå\nHasar på rutten tå\nHjärnorna de smakar så härligt\nLikstelheten knakar helt förfärligt\nKöttet rått och skinnet grått\nDe fälls av ett huvudskott\n\nEn elak man från Helsingfors\nHan åkallade Satan\nMed blåvitt inverterat kors\nMen han var för lat, han\nStackars lille djävulspräst\nFinska Necronomicon är svårläst\n\nElof var en excorcist\nIfall att du blir besatt\nKrucifix mot Antikrist\nOnda skratt i julenatt\nEn gång var den besatte för galen\nElof läste fel i ritualen\nPlötsligt hördes det ett dån\nHan svaldes av en demon\n\nBirger är en lykantrop\nHan ylar som en fåne\nVresigt pälsklädd, snar till dråp\nAllt för den fulla måne\nDräpes lätt med silverspett\nAkta dig för varulvsbett, din jävel\n\nGillar du att äta lik?\nOnd bråd död, ditt levebröd\nDå är varje kyrkogård ett fik\nIngen tid för griftefrid\nOfferbål i natten vi tända\nKom och låt oss gravarna skända\nVarje jul i detta land\nEn kyrka blir satt i brand",
+			"author": "J. Strauss, Strauss ex Machina"
 		},
 		{
 			"id": 136,
 			"title": "Sång till Stor-MUX",
-			"author": "Erik Lundberg och Wilhelm Svenselius",
 			"melody": "Balladen om Theobald Thor",
 			"tags": ["esoteric", "swe"],
-			"content": "En MUX som hette Ann-Sofi Åhn,\nhon hade en stekpanna av Teflon,\nI den la' hon sin mobiltelefon\nsom genast sprängdes med schwung!\n\nDet var ett stort schwung!\nLångt, kraftigt och tungt!\nFrån dess topp till dess rot, var det tre fyra fot\noch en medelstor ryggsäck till\nschwung, schwung, schwung,\nschwungeli schwung,\nschwung, schwung schwung...\n\nNu har hon ingen telefon,\nhon fick köpa sig en megafon.\nSe'n skrek hon i sin mikrofon\nså att ingen fick sova en blund!\n\nDet var en stor blund...\n\nKassören han blev helt bestört,\ninvITen skrek nåt' oerhört,\nPhöz tog varsin citodon\noch tystade Ann-Sofi Åhn!\n\nDet var en stor Åhn...\n\nMen phöz tar inte Ann-Sofi!\nDe fick allt göra snabb sorti\noch Överphöz till sjukan går\nför att vårda ett sår på sitt lår.\n\nDet var ett stort lår...\n\ninvITen dom gick också bet.\nI Ann-Sofi dom drog och slet,\nförlorade kampen och gick på lunch\nför att dricka en flaska med punsch!\n\nDet var en stor punsch...\n\nAllt hopp vi ställde till vår kassör,\nhan vet hur storMUXen tämjas bör.\nHan öppnade fort ett sopnedkast\noch hystade henne med hast!\n\nDet var en stor hast...\n\nFast sagan fick ett lyckligt slut,\nen faxmaskin vi köpte ut\nav märket Konglig Electrolux\nsen skänkte vi den till vår MUX!\n\nDet var en stor MUX..."
+			"content": "En MUX som hette Ann-Sofi Åhn,\nhon hade en stekpanna av Teflon,\nI den la' hon sin mobiltelefon\nsom genast sprängdes med schwung!\n\nDet var ett stort schwung!\nLångt, kraftigt och tungt!\nFrån dess topp till dess rot, var det tre fyra fot\noch en medelstor ryggsäck till\nschwung, schwung, schwung,\nschwungeli schwung,\nschwung, schwung schwung...\n\nNu har hon ingen telefon,\nhon fick köpa sig en megafon.\nSe'n skrek hon i sin mikrofon\nså att ingen fick sova en blund!\n\nDet var en stor blund...\n\nKassören han blev helt bestört,\ninvITen skrek nåt' oerhört,\nPhöz tog varsin citodon\noch tystade Ann-Sofi Åhn!\n\nDet var en stor Åhn...\n\nMen phöz tar inte Ann-Sofi!\nDe fick allt göra snabb sorti\noch Överphöz till sjukan går\nför att vårda ett sår på sitt lår.\n\nDet var ett stort lår...\n\ninvITen dom gick också bet.\nI Ann-Sofi dom drog och slet,\nförlorade kampen och gick på lunch\nför att dricka en flaska med punsch!\n\nDet var en stor punsch...\n\nAllt hopp vi ställde till vår kassör,\nhan vet hur storMUXen tämjas bör.\nHan öppnade fort ett sopnedkast\noch hystade henne med hast!\n\nDet var en stor hast...\n\nFast sagan fick ett lyckligt slut,\nen faxmaskin vi köpte ut\nav märket Konglig Electrolux\nsen skänkte vi den till vår MUX!\n\nDet var en stor MUX...",
+			"author": "Erik Lundberg och Wilhelm Svenselius, IT-03 (KTH)"
 		},
 		{
 			"id": 137,
 			"title": "Bacchivisan",
-			"author": "Kjell Ahlström",
 			"melody": "Agadoo (ungefär)",
 			"tags": ["esoteric", "swe"],
-			"content": "När jag slutade 9:an,\nja då tänkte jag som så.\nJag skall ej bliva lodis,\njag skall gå på KTH.\n\nSå i spårval jag valde\natt i nördars fotspår gå\nLäsa teknikers linje\nme'ns de andra kröka på.\n\nFör Bacchus älskar ju dem,\nsom älskar vin, sex och sång!\nMens de som drack vid sexton\nej kunde sjunga en gång!\n\nSå jag började på IT\nför att blifva Bacchus vän.\nLärde mig snart att sjunga\nav den goda invITen.\n\nÅ jag började att dricka,\ngöra spex och hyssa på.\nJa du jävlar du skall se,\ndet blev blött på KTH.\n\nFör Bacchus älskar ju dem,\nsom älskar vin, sex och sång!\nMen det blev inte en gång\njag fick ett streck på min stång.\n\n\"Var e brudarna?\"\n\nNär jag slutade på IT\nvar det dags att jobbet få.\nSå jag visade CV:t\nå där stod det liksom så:\n\n\"Jag kan kasta en stövel,\nstjäla skyltar, supa på.\"\nÅ då jävlar de visste,\nhan har gått på KTH!\n\nFör Bacchus älskar ju dem,\nsom älskar vin, sex och sång!\nMen kvinnor älskar ju dem\nsom kan nåt annat än Pong!\n\nSedan återkom bubblan\noch min avskedning blev snar.\nTorska hus, bil och kvinna,\nmen se törsten den blev kvar!\n\nSå jag satt där på bänken,\nsila T-röd och sjöng på,\nom de bäskaste droppar\noch att gå på KTH.\n\nFör Bacchus älskar ju dem,\nsom älskar vin, sex och sång!\nMen det gör Charon också\nså jag blev blott trettitvå.\n\nNär jag så kom till Hades\nmötte jag honom till slut.\nLilla sjungande Bacchus,\ngud till var och en suput.\n\nI hans näve fanns bäsken\noch se schmecken den satt på!\nJa man borde ha anat, han\nhar gått på KTH!"
+			"content": "När jag slutade 9:an,\nja då tänkte jag som så.\nJag skall ej bliva lodis,\njag skall gå på KTH.\n\nSå i spårval jag valde\natt i nördars fotspår gå\nLäsa teknikers linje\nme'ns de andra kröka på.\n\nFör Bacchus älskar ju dem,\nsom älskar vin, sex och sång!\nMens de som drack vid sexton\nej kunde sjunga en gång!\n\nSå jag började på IT\nför att blifva Bacchus vän.\nLärde mig snart att sjunga\nav den goda invITen.\n\nÅ jag började att dricka,\ngöra spex och hyssa på.\nJa du jävlar du skall se,\ndet blev blött på KTH.\n\nFör Bacchus älskar ju dem,\nsom älskar vin, sex och sång!\nMen det blev inte en gång\njag fick ett streck på min stång.\n\n\"Var e brudarna?\"\n\nNär jag slutade på IT\nvar det dags att jobbet få.\nSå jag visade CV:t\nå där stod det liksom så:\n\n\"Jag kan kasta en stövel,\nstjäla skyltar, supa på.\"\nÅ då jävlar de visste,\nhan har gått på KTH!\n\nFör Bacchus älskar ju dem,\nsom älskar vin, sex och sång!\nMen kvinnor älskar ju dem\nsom kan nåt annat än Pong!\n\nSedan återkom bubblan\noch min avskedning blev snar.\nTorska hus, bil och kvinna,\nmen se törsten den blev kvar!\n\nSå jag satt där på bänken,\nsila T-röd och sjöng på,\nom de bäskaste droppar\noch att gå på KTH.\n\nFör Bacchus älskar ju dem,\nsom älskar vin, sex och sång!\nMen det gör Charon också\nså jag blev blott trettitvå.\n\nNär jag så kom till Hades\nmötte jag honom till slut.\nLilla sjungande Bacchus,\ngud till var och en suput.\n\nI hans näve fanns bäsken\noch se schmecken den satt på!\nJa man borde ha anat, han\nhar gått på KTH!",
+			"author": "Kjell Ahlström (KTH)"
 		},
 		{
 			"id": 138,
 			"title": "Tentavakten",
-			"author": "Erik Rålenius",
 			"melody": "Du gamla, du fria",
 			"tags": ["esoteric", "swe"],
-			"content": "Du gamla du fina du stolta tentavakt.\nDu vakar över skrivande studenter.\nDu önskar att allt kunde\nbli som det var,\npå ljuva 1920-talet.\n\nDu fuktar ditt finger\noch räknar mina blad,\noch ser till att jag fyllt försättsbladet,\noch drömmer dig bort\noch önskar att du åter var\nstudent på 1920-talet."
+			"content": "Du gamla du fina du stolta tentavakt.\nDu vakar över skrivande studenter.\nDu önskar att allt kunde\nbli som det var,\npå ljuva 1920-talet.\n\nDu fuktar ditt finger\noch räknar mina blad,\noch ser till att jag fyllt försättsbladet,\noch drömmer dig bort\noch önskar att du åter var\nstudent på 1920-talet.",
+			"author": "Erik Rålenius, IT (KTH)"
 		},
 		{
 			"id": 139,
 			"title": "Vart tog den schlema lilla nØllan vägen?",
-			"author": "Kjell Ahlström",
 			"melody": "Vart tog den söta lilla flickan vägen",
 			"tags": ["esoteric", "swe"],
-			"content": "\"Du Konglig?\"\n\"Ja?\"\n\"Ibland e groggen för stor men oftast e den för liten.\"\n\"Mm, så är det.\"\n\n//: Vart tog den schlema lilla nØllan vägen? :// (3x)\nIngen som vet, ingen som vet!\n\n//: Vart tog den schlema lilla nØllan vägen? :// (3x)\nIngen som vet, ingen som vet!\n\nKolla ettans homies,\nde verkar inte för-stå!\nLilla dumma nØllan\ntycks å palla K å T, H!\nHan fick ju bara IGn?\nHur fan tog han sig in?\nPå IT och ME är kraven ingenting!\n\nHur fan ska han det klara?\nVänta lite bara!\nHjältarna i mantlar\ntycks komma i en skara!\n\"Höger hand på höger axel\"\nsägs i gnällig röst,\nsen vandrar de iväg,\ni schlemled blir han phöst.\n\nFördömt! Likt lära snorvalp cykla,\nbörjar likt förbannat han\nokynnesgyckla.\nSe schlemet där vid bordet\nsom dreglar massa schnor.\nJag har tröttnat,\nskicka hit min re-gu-la-tor!\n\nMah, mah!\nKolla nØllan, han är en sån geek!\nMen Konglig är coolhet - logik!\nViolett matchar skitbra till svart!\nOch nu undrar ni vart...\n\n//: Vart tog den schlema lilla nØllan vägen? :// (3x)\nIngen som vet, ingen som vet!\n//: Vart tog den schlema lilla nØllan vägen? :// (3x)\nIngen som vet, ingen som vet!\n\nOch vad har han för idoler?\nKolla nØllans vägg!\nFörut var det Handels,\nvad är det nu för drägg\nmed skägg! Och pyntade schmeckar,\nlånga mantlar och fasta häckar!\nHan blir aldrig töntig ekonom igen,\nhar betan till bibel och datorn som vän.\n\nNu är det andra dryckjom han kräver:\nBäska droppar och bärs han häver!\nOch snuskiga små gyckel\nsom trotsar kårens bruk,\nsubliminala hintar,\nvad rimmar på \"duk\"?\n\nOch lämna aldrig er\nsäkra brandvägg öppen,\ndå sprids skitsnabbt ryktena\nom sexleksaksköpen.\nVem fan är det som tullar\ni Kongligs egen bar?\nBOOM!\n\n\"Så går det för den nØllan som ambrosiak tar!\""
+			"content": "\"Du Konglig?\"\n\"Ja?\"\n\"Ibland e groggen för stor men oftast e den för liten.\"\n\"Mm, så är det.\"\n\n//: Vart tog den schlema lilla nØllan vägen? :// (3x)\nIngen som vet, ingen som vet!\n\n//: Vart tog den schlema lilla nØllan vägen? :// (3x)\nIngen som vet, ingen som vet!\n\nKolla ettans homies,\nde verkar inte för-stå!\nLilla dumma nØllan\ntycks å palla K å T, H!\nHan fick ju bara IGn?\nHur fan tog han sig in?\nPå IT och ME är kraven ingenting!\n\nHur fan ska han det klara?\nVänta lite bara!\nHjältarna i mantlar\ntycks komma i en skara!\n\"Höger hand på höger axel\"\nsägs i gnällig röst,\nsen vandrar de iväg,\ni schlemled blir han phöst.\n\nFördömt! Likt lära snorvalp cykla,\nbörjar likt förbannat han\nokynnesgyckla.\nSe schlemet där vid bordet\nsom dreglar massa schnor.\nJag har tröttnat,\nskicka hit min re-gu-la-tor!\n\nMah, mah!\nKolla nØllan, han är en sån geek!\nMen Konglig är coolhet - logik!\nViolett matchar skitbra till svart!\nOch nu undrar ni vart...\n\n//: Vart tog den schlema lilla nØllan vägen? :// (3x)\nIngen som vet, ingen som vet!\n//: Vart tog den schlema lilla nØllan vägen? :// (3x)\nIngen som vet, ingen som vet!\n\nOch vad har han för idoler?\nKolla nØllans vägg!\nFörut var det Handels,\nvad är det nu för drägg\nmed skägg! Och pyntade schmeckar,\nlånga mantlar och fasta häckar!\nHan blir aldrig töntig ekonom igen,\nhar betan till bibel och datorn som vän.\n\nNu är det andra dryckjom han kräver:\nBäska droppar och bärs han häver!\nOch snuskiga små gyckel\nsom trotsar kårens bruk,\nsubliminala hintar,\nvad rimmar på \"duk\"?\n\nOch lämna aldrig er\nsäkra brandvägg öppen,\ndå sprids skitsnabbt ryktena\nom sexleksaksköpen.\nVem fan är det som tullar\ni Kongligs egen bar?\nBOOM!\n\n\"Så går det för den nØllan som ambrosiak tar!\"",
+			"author": "Kjell Ahlström (KTH)"
 		},
 		{
 			"id": 140,
 			"title": "Starke Arvid",
-			"author": "Ola, Frukt och Flingor, 1979",
 			"tags": ["esoteric", "swe"],
-			"content": "Som liten var Arvid rätt svag\nhan led utav blodbrist vad dag.\nI skolan han hade det trist,\ni idrott han alltid blev sist.\n\nMen nu är han vuxen, minsann.\nEn sjutusan till karl, stor och grann.\nFör nu käkar han massor av mat,\noch proppar sig full med\nhormonpreparat.\n\nStarke Arvid han kan lyfta tåg och bil,\nhan kan springa över flera hundra mil.\nStarke Arvid han är inte längre svag,\nhan kan snart ta guld i en olympiad.\n\nJa som grabb så var Arvid så klen,\nhan var mager om armar och ben.\nI plugget han hade det svårt,\nblev mobbad tills han föll i gråt.\n\nMen nu är han stark ska ni se,\ndär ligger Karl-Alfred i lä.\nFör Arvid han lassar in mat,\noch proppar sig full med\nhormonpreparat.\n\nStarke Arvid han kan lyfta...\n\nOch brudarna smälter som smör,\nför Arvid har blivit charmör.\nHan är deras nya idol,\nhans armar och ben är som stål.\n\nI tävling han ger ingen nåd,\nhan slår alla gamla rekord.\nJa så har det äntligen hänt,\nnu har Ricky Bruch fått\nen stor konkurrent.\n\nStarke Arvid han kan lyfta..."
+			"content": "Som liten var Arvid rätt svag\nhan led utav blodbrist vad dag.\nI skolan han hade det trist,\ni idrott han alltid blev sist.\n\nMen nu är han vuxen, minsann.\nEn sjutusan till karl, stor och grann.\nFör nu käkar han massor av mat,\noch proppar sig full med\nhormonpreparat.\n\nStarke Arvid han kan lyfta tåg och bil,\nhan kan springa över flera hundra mil.\nStarke Arvid han är inte längre svag,\nhan kan snart ta guld i en olympiad.\n\nJa som grabb så var Arvid så klen,\nhan var mager om armar och ben.\nI plugget han hade det svårt,\nblev mobbad tills han föll i gråt.\n\nMen nu är han stark ska ni se,\ndär ligger Karl-Alfred i lä.\nFör Arvid han lassar in mat,\noch proppar sig full med\nhormonpreparat.\n\nStarke Arvid han kan lyfta...\n\nOch brudarna smälter som smör,\nför Arvid har blivit charmör.\nHan är deras nya idol,\nhans armar och ben är som stål.\n\nI tävling han ger ingen nåd,\nhan slår alla gamla rekord.\nJa så har det äntligen hänt,\nnu har Ricky Bruch fått\nen stor konkurrent.\n\nStarke Arvid han kan lyfta...",
+			"author": "Ola, Frukt och Flingor (1979)"
 		},
 		{
 			"id": 141,
 			"title": "Man ska gå ME",
-			"author": "Viktor Åberg",
 			"melody": "Man ska ha husvagn",
 			"composer": "Claes Eriksson",
 			"tags": ["esoteric", "swe"],
-			"content": "Jag har kört nästan alla kurser jag provat på.\nI termo och i våg och i matten likaså.\nJag va osäker men nu vet jag att jag har\nvalt ett bra program som jag aldrig klarar av\n\nMan ska gå ME, så att man sliter sig isär,\nman ska gå ME, utan fritid blir allt bra.\nMan ska gå ME, då blir det inget dagsljus nej,\nman ska gå ME, här finns inga tjejer.\\*\n\nFem minuter kvant och fem minuter termo,\nfem minuter TET och fem minuter bärvåg,\nfem minuter vin och fem minuter fest,\nfem minuters sömn i soffan på plan 6.\n\n> \\* \"här finns inga tjejer\" ska sjungas med tragedi, eftersom det inte var något\n> som celebrerades utan ett plågsamt faktum år 2004, när låten skrevs."
+			"content": "Jag har kört nästan alla kurser jag provat på.\nI termo och i våg och i matten likaså.\nJag va osäker men nu vet jag att jag har\nvalt ett bra program som jag aldrig klarar av\n\nMan ska gå ME, så att man sliter sig isär,\nman ska gå ME, utan fritid blir allt bra.\nMan ska gå ME, då blir det inget dagsljus nej,\nman ska gå ME, här finns inga tjejer.\\*\n\nFem minuter kvant och fem minuter termo,\nfem minuter TET och fem minuter bärvåg,\nfem minuter vin och fem minuter fest,\nfem minuters sömn i soffan på plan 6.\n\n> \\* \"här finns inga tjejer\" ska sjungas med tragedi, eftersom det inte var något\n> som celebrerades utan ett plågsamt faktum år 2004, när låten skrevs.",
+			"author": "Viktor Åberg (KTH)"
 		},
 		{
 			"id": 142,
@@ -1199,10 +1204,10 @@
 		{
 			"id": 143,
 			"title": "Osqvik",
-			"author": "Strängteoretiquerna, 2015",
 			"melody": "Vi äro musikanter",
 			"tags": ["esoteric", "swe"],
-			"content": "På Wermdö står en stuga,\nrätt liten och rätt kass.\nOch vattnet smakar illa,\nman går på utedass.\n\nMen på Osqvik kan man festa natten lång,\nbada, basta, sjunga massa sång.\n\nOch vi kan dricka rom-fadderalla,\nrom-fadderalla, rom-fadderalla.\nVi kan drick rom-fadderalla.\nRom åt alla, hej!"
+			"content": "På Wermdö står en stuga,\nrätt liten och rätt kass.\nOch vattnet smakar illa,\nman går på utedass.\n\nMen på Osqvik kan man festa natten lång,\nbada, basta, sjunga massa sång.\n\nOch vi kan dricka rom-fadderalla,\nrom-fadderalla, rom-fadderalla.\nVi kan drick rom-fadderalla.\nRom åt alla, hej!",
+			"author": "Strängteoretiquerna, IT (KTH, 2015)"
 		},
 		{
 			"id": 144,
@@ -1222,41 +1227,41 @@
 		{
 			"id": 146,
 			"title": "invITensången",
-			"author": "Daniel Byström",
 			"melody": "Kungssången",
 			"composer": "Otto Lindblad",
 			"tags": ["solemn", "swe"],
-			"content": "invITen ståtlig, ack så vis,\nvi skänka eder vårt bevis\npå I-Teknologins makt.\n\nDe står med stolthet och bravur,\nde kämpar mot lågkonjunktur.\nAnammar äkta hack-kultur\ndu stolta ingenjör!\n\nDu stolta IT-fana så,\nvår gud med glädje lysa så:\ninvITen träder fram!\nPresenterar IT för vår värld,\nstoltserar fint i prakt och flärd,\nförbättrar världen med teknik.\nJa, glädje skapas då!"
+			"content": "invITen ståtlig, ack så vis,\nvi skänka eder vårt bevis\npå I-Teknologins makt.\n\nDe står med stolthet och bravur,\nde kämpar mot lågkonjunktur.\nAnammar äkta hack-kultur\ndu stolta ingenjör!\n\nDu stolta IT-fana så,\nvår gud med glädje lysa så:\ninvITen träder fram!\nPresenterar IT för vår värld,\nstoltserar fint i prakt och flärd,\nförbättrar världen med teknik.\nJa, glädje skapas då!",
+			"author": "Daniel Byström (KTH)"
 		},
 		{
 			"id": 147,
 			"title": "Kungssången",
-			"author": "C.V.A.Strandberg och Otto Lindblad, 1844",
 			"tags": ["solemn", "swe"],
-			"content": "Ur svenska hjärtans djup en gång\nen samfälld och en enkel sång,\nsom går till Kungen fram!\n\nVar Honom trofast och Hans ätt,\ngör kronan på Hans hjässa lätt,\noch all din tro till Honom sätt,\ndu folk av frejdad stam!"
+			"content": "Ur svenska hjärtans djup en gång\nen samfälld och en enkel sång,\nsom går till Kungen fram!\n\nVar Honom trofast och Hans ätt,\ngör kronan på Hans hjässa lätt,\noch all din tro till Honom sätt,\ndu folk av frejdad stam!",
+			"author": "C.V.A.Strandberg och Otto Lindblad (1844)"
 		},
 		{
 			"id": 148,
 			"title": "Stockholm i mitt hjärta",
-			"author": "Lasse Berghagen",
 			"tags": ["solemn", "swe"],
-			"content": "Solljuset stiger ur havet,\nspelar i koppar och glas.\nStockholm i gryningen strålar\nsom var hon en gyllene vas.\nMed blommor från Östersjöns stränder,\nmed ängsört från ekarnas sal,\nen skönhet på urbergets stränder,\nMälarens ljuva vestal.\n\nStockholm i mitt hjärta,\nlåt mig besjunga dig nu,\nåldrad i ungdomlig grönska,\nöarnas stad, det är du!\nAv städer jag känner i världen\när du den stad som fått allt.\nGenom Mälarens kärlek till havet\när du en blandning av sött och salt.\n\nSolljuset dansar på fjärden,\ndet glittrar för stort och för smått.\nFör träkåken uppe på Söder\nmen även för Konungens slott.\nDet porlar i fiskrika strömmar,\ndet valsar i Mälarens famn,\ndet skymmer och skänker oss drömmar\nsjungandes sjöstadens namn.\n\nStockholm i mitt hjärta...\n\nSkymningen kom i en smekning\nav kvällsbrisens skälvande hand.\nNu rodnar solen i fönstren\npå Söder och Norr Mälarstrand.\nSäj, hör du musiken och skratten\nfrån Djurgården och Gröna Lund,\nen lovsång till Stockholm i natten\nfrån skärgårdens vikar och sund.\n\nStockholm i mitt hjärta..."
+			"content": "Solljuset stiger ur havet,\nspelar i koppar och glas.\nStockholm i gryningen strålar\nsom var hon en gyllene vas.\nMed blommor från Östersjöns stränder,\nmed ängsört från ekarnas sal,\nen skönhet på urbergets stränder,\nMälarens ljuva vestal.\n\nStockholm i mitt hjärta,\nlåt mig besjunga dig nu,\nåldrad i ungdomlig grönska,\nöarnas stad, det är du!\nAv städer jag känner i världen\när du den stad som fått allt.\nGenom Mälarens kärlek till havet\när du en blandning av sött och salt.\n\nSolljuset dansar på fjärden,\ndet glittrar för stort och för smått.\nFör träkåken uppe på Söder\nmen även för Konungens slott.\nDet porlar i fiskrika strömmar,\ndet valsar i Mälarens famn,\ndet skymmer och skänker oss drömmar\nsjungandes sjöstadens namn.\n\nStockholm i mitt hjärta...\n\nSkymningen kom i en smekning\nav kvällsbrisens skälvande hand.\nNu rodnar solen i fönstren\npå Söder och Norr Mälarstrand.\nSäj, hör du musiken och skratten\nfrån Djurgården och Gröna Lund,\nen lovsång till Stockholm i natten\nfrån skärgårdens vikar och sund.\n\nStockholm i mitt hjärta...",
+			"author": "Lasse Berghagen (1995)"
 		},
 		{
 			"id": 149,
 			"title": "Du gamla, du fria",
-			"author": "Richard Dybeck, 1844",
 			"tags": ["solemn", "swe"],
-			"content": "Du gamla, du fria, du fjällhöga Nord,\ndu tysta, du glädjerika sköna!\nJag hälsar dig, vänaste land uppå jord.\n//: Din sol, din himmel,\ndina ängder gröna! ://\n\nDu tronar på minnen från fornstora dar,\ndå ärat ditt namn flög över jorden.\nJag vet att du är och du blir vad du var.\n//: Ja, jag vill leva,\njag vill dö i Norden! ://"
+			"content": "Du gamla, du fria, du fjällhöga Nord,\ndu tysta, du glädjerika sköna!\nJag hälsar dig, vänaste land uppå jord.\n//: Din sol, din himmel,\ndina ängder gröna! ://\n\nDu tronar på minnen från fornstora dar,\ndå ärat ditt namn flög över jorden.\nJag vet att du är och du blir vad du var.\n//: Ja, jag vill leva,\njag vill dö i Norden! ://",
+			"author": "Richard Dybeck (1844)"
 		},
 		{
 			"id": 150,
 			"title": "O, gamla klang- och jubeltid!",
-			"author": "August Lindh, 1921",
 			"melody": "O alte Burschenherrlichkeit",
-			"composer": "Eugen Höfling, 1825",
+			"composer": "Eugen Höfling (1825)",
 			"tags": ["solemn", "swe"],
-			"content": "O gamla klang- och jubeltid\nditt minne skall förbliva\noch än åt livets bistra strid,\nett rosigt skimmer giva.\nSnart tystnar allt vårt yra skämt,\nvår sång blir stum, vårt glam förstämt.\n\nO, jerum, jerum, jerum.\nO, quae mutatio rerum!\n\nVar äro de som kunde allt,\nblott ej sin ära svika.\nSom voro män av äkta halt\noch världens herrar lika?\nDe drogo bort från vin och sång\ntill vardagslivets tråk och tvång.\n\nO, jerum...\n\nDen ene vetenskap och vett\nin i scholares mänger.\nDen andre i sitt anlets svett\npå paragrafer vränger.\nEn plåstrar själen som är skral,\nen lappar hop dess trasiga fodral.\n\nO, jerum...\n\nMen hjärtat i en sann student,\nkan ingen tid förfrysa.\nDen glädjeeld, som där han tänt,\nhans hela liv skall lysa.\n\nDet gamla skalet brustit har\nmen kärnan finnes frisk dock kvar\noch vad han än må mista,\nden skall dock aldrig brista!\n\nSå sluten, bröder, fast vår krets,\ntill glädjens värn och ära!\nTrots allt vi tryggt och väl tillfreds\nvår vänskap trohet svära.\n\nLyft bägarn högt och klinga väl!\nDe gamla gudar leva än,\nbland skålar och pokaler,\nbland skålar och pokaler!"
+			"content": "O gamla klang- och jubeltid\nditt minne skall förbliva\noch än åt livets bistra strid,\nett rosigt skimmer giva.\nSnart tystnar allt vårt yra skämt,\nvår sång blir stum, vårt glam förstämt.\n\nO, jerum, jerum, jerum.\nO, quae mutatio rerum!\n\nVar äro de som kunde allt,\nblott ej sin ära svika.\nSom voro män av äkta halt\noch världens herrar lika?\nDe drogo bort från vin och sång\ntill vardagslivets tråk och tvång.\n\nO, jerum...\n\nDen ene vetenskap och vett\nin i scholares mänger.\nDen andre i sitt anlets svett\npå paragrafer vränger.\nEn plåstrar själen som är skral,\nen lappar hop dess trasiga fodral.\n\nO, jerum...\n\nMen hjärtat i en sann student,\nkan ingen tid förfrysa.\nDen glädjeeld, som där han tänt,\nhans hela liv skall lysa.\n\nDet gamla skalet brustit har\nmen kärnan finnes frisk dock kvar\noch vad han än må mista,\nden skall dock aldrig brista!\n\nSå sluten, bröder, fast vår krets,\ntill glädjens värn och ära!\nTrots allt vi tryggt och väl tillfreds\nvår vänskap trohet svära.\n\nLyft bägarn högt och klinga väl!\nDe gamla gudar leva än,\nbland skålar och pokaler,\nbland skålar och pokaler!",
+			"author": "August Lindh (Juvenalorden, Uppsala, 1921)"
 		},
 		{
 			"id": 151,
@@ -1265,5 +1270,5 @@
 			"content": "> Sjunges alltid som gasquens sista sång.\n\nHur gärna ville jag ej vara,\nen liten blå förgätmigej,\nen liten blå förgätmigej!\n\nDå skulle jag för dig förklara,\nhur innerligt jag älskar dig!"
 		}
 	],
-	"updatedAt": "2025-03-13"
+	"updatedAt": "2025-03-20"
 }

--- a/dist/songs.xml
+++ b/dist/songs.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<songs description="IT-sektionens sångbok, Strängteoretiquernas reviderade version (2009-2015)" updated="2025-03-20">
+<songs description="IT-sektionens sångbok, Strängteoretiquernas reviderade version (2009-2015)" updated="2025-03-22">
 	<song
 		name="Moder Kista"
 		id="0"
-		author="David Larsson, IT-00 (KTH, 2000)"
+		author="David Larsson, IT-00 (IT-nØllningen, KTH, 2000)"
 		composer="Otto Lindblad"
 		melody="Längtan till landet"
 		category="Gasque"
@@ -115,7 +115,7 @@
 	<song
 		name="Jag ska festa"
 		id="3"
-		author="Stefan 'Stege' Gennert, D-86, och Anders 'Pellefjant' Bjerkén, D-87 (Sångarstriden, Lund, 1987)"
+		author="Stefan "Stege" Gennert, D-86, och Anders "Pellefjant" Bjerkén, D-87 (Sångarstriden, Lund, 1987)"
 		composer="Sten Carlberg"
 		melody="Bamsesången"
 		category="Gasque"
@@ -587,7 +587,7 @@
 	<song
 		name="Jag var full en gång..."
 		id="11"
-		composer="Hugo Lindh, Gösta 'Snoddas' Nordgren"
+		composer="Hugo Lindh, Gösta "Snoddas" Nordgren"
 		melody="Flottarkärlek"
 		category="Gasque"
 	>
@@ -838,7 +838,7 @@
 	<song
 		name="När jag är fuller"
 		id="15"
-		author="Tore 'Pekka' Norén, B (Sångartäflan, KTH, 1942)"
+		author="Tore "Pekka" Norén, B (Sångartäflan,, KTH,, 1942)"
 		melody="När månen vandrar"
 		category="Gasque"
 	>
@@ -1378,7 +1378,7 @@
 	<song
 		name="Viking Raiders"
 		id="154"
-		author="Samuel Larsson, IT (KTH, 2020)"
+		author="Samuel Larsson, IT-17 (KTH, 2020)"
 		melody="Spanish Ladies"
 		category="Gasque"
 	>
@@ -2038,8 +2038,8 @@
 	<song
 		name="Längtan till landet"
 		id="55"
-		author="Herman Sätherberg och Otto Lindblad (1838)"
-		composer="Herman Sätherberg och Otto Lindblad"
+		author="Herman Sätherberg (1838)"
+		composer="Otto Lindblad"
 		category="Wihn"
 	>
 		<p>
@@ -3491,6 +3491,7 @@
 		name="Härlig är punschen"
 		id="110"
 		author="(Juristspexet Ansgar, 2003)"
+		composer="Johann Sebastian Bach"
 		melody="Nu grönskar det"
 		category="Punsch"
 	>
@@ -3519,7 +3520,7 @@
 		name="Nu blotas det"
 		id="111"
 		author="(Juristspexet Ansgar, 2003)"
-		composer="Johann Sebastian Bac"
+		composer="Johann Sebastian Bach"
 		melody="Nu grönskar det"
 		category="Punsch"
 	>
@@ -3549,7 +3550,7 @@
 		id="112"
 		author="DKM (KTH, 2000)"
 		composer="John Williams"
-		melody="Imperial march, Star Wars"
+		melody="Imperial march (Star Wars)"
 		category="Punsch"
 	>
 		<p>
@@ -3643,7 +3644,7 @@
 	<song
 		name="I Love Punsch"
 		id="159"
-		author="Samuel Larsson, IT (KTH, 2020)"
+		author="Samuel Larsson, IT-17 (KTH, 2020)"
 		composer="Ben Oakland and Milton Drake"
 		melody="Java Jive"
 		category="Punsch"
@@ -3664,7 +3665,7 @@
 	<song
 		name="Barrett's Privateers"
 		id="114"
-		author="Stan Rogers"
+		author="Stan Rogers (1976)"
 		category="Utländskt"
 	>
 		<p>
@@ -4263,7 +4264,7 @@
 	<song
 		name="Unix Man"
 		id="124"
-		author="Bran Morrison"
+		author="Brad Morrison"
 		composer="John Lennon and Paul McCartney"
 		melody="Nowhere Man"
 		category="Nördigt"
@@ -4460,7 +4461,7 @@
 		name="Write in C"
 		id="161"
 		author="Jay Piecora (SUNY Binghamton)"
-		composer="John Lennon, Paul McCartney"
+		composer="John Lennon och Paul McCartney"
 		melody="Let It Be"
 		category="Nördigt"
 	>
@@ -4823,7 +4824,7 @@
 		name="Sång till Stor-MUX"
 		id="136"
 		author="Erik Lundberg och Wilhelm Svenselius, IT-03 (KTH)"
-		melody="Balladen om Theobald Thor"
+		melody="The Ball of Kirriemuir (Balladen om Theobald Thor)"
 		category="Esoterica"
 	>
 		<p>

--- a/dist/songs.xml
+++ b/dist/songs.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<songs description="IN-sektionens sångbok, Strängteoretiquernas reviderade version (2009-2015)" updated="2025-03-13">
+<songs description="IT-sektionens sångbok, Strängteoretiquernas reviderade version (2009-2015)" updated="2025-03-20">
 	<song
 		name="Moder Kista"
 		id="0"
-		author="David Larsson, IT00"
+		author="David Larsson, IT-00 (KTH, 2000)"
 		composer="Otto Lindblad"
 		melody="Längtan till landet"
 		category="Gasque"
@@ -46,9 +46,9 @@
 		</p>
 	</song>
 	<song
-		name="Dance macabre"
+		name="Danse macabre"
 		id="1"
-		author="Carl-Erik Carlstedt, Chalmers"
+		author="Carl-Erik Carlstedt (Chalmers)"
 		melody="Vårvindar friska"
 		category="Gasque"
 	>
@@ -80,7 +80,7 @@
 	<song
 		name="Porthos visa"
 		id="2"
-		author="Tore Norén, Bergsspexet, 1960"
+		author="Tord Andrén, B (Bergsspexet, KTH, 1960 — Ursprungligen Athos visa)"
 		composer="Irving Berlin"
 		melody="You can't get a man with a gun"
 		category="Gasque"
@@ -115,7 +115,7 @@
 	<song
 		name="Jag ska festa"
 		id="3"
-		author="Stefan 'Stege' Gennert och Anders 'Pellefjant' Bjerkén, Sångarstriden Lund, 1987"
+		author="Stefan 'Stege' Gennert, D-86, och Anders 'Pellefjant' Bjerkén, D-87 (Sångarstriden, Lund, 1987)"
 		composer="Sten Carlberg"
 		melody="Bamsesången"
 		category="Gasque"
@@ -154,7 +154,7 @@
 	<song
 		name="Lyft ditt välförsedda glas"
 		id="4"
-		author="Medicinarspexet Göteborg, 1970"
+		author="(Medicinarspexet, Göteborg, 1970)"
 		composer="Jehan Tabourot, George Ratcliffe Woodward, Charles Wood"
 		melody="Ding dong merrily on high"
 		category="Gasque"
@@ -186,7 +186,7 @@
 	<song
 		name="Fredmans sång nr. 21"
 		id="5"
-		author="Carl Michael Bellman"
+		author="Carl Michael Bellman (1787)"
 		composer="Carl Michael Bellman"
 		category="Gasque"
 	>
@@ -308,7 +308,7 @@
 	<song
 		name="Härjarevisan"
 		id="6"
-		author="Lundaspexet Djingis Khan, 1954"
+		author="(Lundaspexet Djingis Khan, 1954)"
 		melody="Gärdebylåten"
 		category="Gasque"
 	>
@@ -404,7 +404,7 @@
 	<song
 		name="Système International"
 		id="9"
-		author="Anders Skog, F-75"
+		author="Anders Skog, F-75 (KTH)"
 		composer="Prins Gustaf av Sverige och Norge"
 		melody="Studentsången"
 		category="Gasque"
@@ -422,9 +422,9 @@
 	<song
 		name="Jag har aldrig..."
 		id="10"
-		author="(Handelsvisan) Team Kangaroo, 1977; (Fysikvisan) DKM, 2000; (Datavisan) Mattis Castegren, 2001"
-		composer="Joël Blomqvist och Per Ollén"
-		melody="O hur saligt att få vandra"
+		author="Team Kangaroo, F (Gerhards-gasque, KTH, 1977 — Handelsvisan); DKM (KTH, 2000 — Fysikvisan); Mattis Castegren (Fysiksektionens Ettans fest, KTH, 2001 — Datavisan)"
+		composer="Robert Lowry"
+		melody="O, hur saligt att få vandra"
 		category="Gasque"
 	>
 		<p>
@@ -782,7 +782,7 @@
 	<song
 		name="Lille Olle"
 		id="13"
-		author="Calle Isaksson, D-LiTH"
+		author="Calle Isaksson, D (LiTH)"
 		composer="Matvey Blanter"
 		melody="Katjuscha"
 		category="Gasque"
@@ -838,7 +838,7 @@
 	<song
 		name="När jag är fuller"
 		id="15"
-		author="Sångartäflan, 1942"
+		author="Tore 'Pekka' Norén, B (Sångartäflan, KTH, 1942)"
 		melody="När månen vandrar"
 		category="Gasque"
 	>
@@ -894,7 +894,7 @@
 	<song
 		name="Störthärligt full"
 		id="16"
-		author="Hittad på Handels, 1981"
+		author="(1981 — Hittad på Handels)"
 		composer="Povel Ramel"
 		melody="Fat Mammy Brown"
 		category="Gasque"
@@ -973,7 +973,7 @@
 	<song
 		name="Bort allt vad oro gör"
 		id="17"
-		author="Carl Michael Bellman"
+		author="Carl Michael Bellman (1783 — Bacchi Tempel sång nr. 17)"
 		composer="Carl Michael Bellman"
 		category="Gasque"
 	>
@@ -1170,7 +1170,7 @@
 	<song
 		name="Anti-snapsvisa"
 		id="23"
-		author="Lundakarnevalen, 1986"
+		author="(Lundakarnevalen, 1986)"
 		composer="Evert Taube"
 		melody="Sjösala vals"
 		category="Gasque"
@@ -1191,7 +1191,7 @@
 	<song
 		name="Cidervisan"
 		id="24"
-		author="Strängteoretiquerna, 2015"
+		author="Strängteoretiquerna, IT (KTH, 2015)"
 		composer="Thorbjørn Egner"
 		melody="Rövarnas visa"
 		category="Gasque"
@@ -1224,7 +1224,7 @@
 	<song
 		name="Vi tar en enkel liten sång"
 		id="25"
-		author="Strängteoretiquerna, 2015"
+		author="Strängteoretiquerna, IT (KTH, 2015)"
 		composer="Jules Sylvain och Sven Paddock"
 		melody="Med en enkel tulipan"
 		category="Gasque"
@@ -1246,7 +1246,7 @@
 	<song
 		name="Treo-comp"
 		id="26"
-		author="Lundakarnevalen, 1986"
+		author="(Lundakarnevalen, 1986)"
 		composer="Otto Lindblad"
 		melody="Längtan till landet"
 		category="Gasque"
@@ -1311,7 +1311,7 @@
 	<song
 		name="Vit vecka"
 		id="29"
-		author="Sångarstriden Lund, 1992"
+		author="(Sångarstriden, Lund, 1992)"
 		composer="Irving Berlin"
 		melody="White Christmas"
 		category="Gasque"
@@ -1378,7 +1378,7 @@
 	<song
 		name="Viking Raiders"
 		id="154"
-		author="Samuel Larsson (2020)"
+		author="Samuel Larsson, IT (KTH, 2020)"
 		melody="Spanish Ladies"
 		category="Gasque"
 	>
@@ -1742,7 +1742,7 @@
 	<song
 		name="Öppna en öhl"
 		id="44"
-		author="Carl Brengesjö, 2013"
+		author="Carl Brengesjö (KTH, 2013)"
 		composer="Tommy Nilsson"
 		melody="Öppna din dörr"
 		category="Öhl"
@@ -1887,7 +1887,7 @@
 	<song
 		name="Elysisk längtan"
 		id="49"
-		author="Sångarstriden Lund, 1968"
+		author="(Sångarstriden, Lund, 1968)"
 		composer="Ludwig van Beethoven"
 		melody="An die Freude (Ode to Joy)"
 		category="Wihn"
@@ -2038,7 +2038,7 @@
 	<song
 		name="Längtan till landet"
 		id="55"
-		author="Herman Sätherberg och Otto Lindblad"
+		author="Herman Sätherberg och Otto Lindblad (1838)"
 		composer="Herman Sätherberg och Otto Lindblad"
 		category="Wihn"
 	>
@@ -2097,7 +2097,7 @@
 	<song
 		name="Tjugotre"
 		id="57"
-		author="Carl Nisser, E-80"
+		author="Carl Nisser, E-80 (KTH)"
 		melody="Amanda Lundbom"
 		category="Brännvin"
 	>
@@ -2397,7 +2397,7 @@
 	<song
 		name="Livet är härligt"
 		id="69"
-		author="Chalmersspexet Katarina II, 1959"
+		author="(Chalmersspexet Katarina II, 1959)"
 		composer="Lev Knipper"
 		melody="Röda kavalleriet (Polyushko-Pole)"
 		category="Brännvin"
@@ -2432,7 +2432,7 @@
 	<song
 		name="Vikingen"
 		id="70"
-		author="Sångarstriden, Lund, 1981"
+		author="E-Sektionen (Sångarstriden, Lund, 1981)"
 		melody="When Johnny comes marching home"
 		category="Brännvin"
 	>
@@ -2646,7 +2646,7 @@
 	<song
 		name="Gräv ur tundran"
 		id="78"
-		author="Ekonomspexet Lenin, 1989"
+		author="(Ekonomspexet Lenin, Stockholms universitet, 1989)"
 		composer="Matvey Blanter"
 		melody="Katjuscha"
 		category="Brännvin"
@@ -2776,7 +2776,7 @@
 	<song
 		name="Häv, häv detta glas"
 		id="83"
-		author="Erik Rålenius"
+		author="Erik Rålenius, IT (KTH)"
 		composer="Alice Tegnér"
 		melody="Bä, bä vita lamm"
 		category="Brännvin"
@@ -2792,7 +2792,7 @@
 	<song
 		name="Spritbolaget"
 		id="84"
-		author="Göran Svensson, Sångarstriden Lund, 1989"
+		author="Göran Svensson (Sångarstriden, Lund, 1989)"
 		composer="Georg Riedel"
 		melody="Du käre lille snickerboa"
 		category="Brännvin"
@@ -2821,7 +2821,7 @@
 	<song
 		name="Rackaren"
 		id="85"
-		author="Kårspexet Munken, 1983"
+		author="(Kårspexet Munken, KTH, 1983)"
 		composer="Georg Philipp Telemann"
 		melody="Hamburger Ebb und Fluth"
 		category="Brännvin"
@@ -2838,7 +2838,7 @@
 	<song
 		name="Ganska nykter"
 		id="86"
-		author="Strängteoretiquerna, 2015"
+		author="Strängteoretiquerna, IT (KTH, 2015)"
 		melody="Vi äro musikanter"
 		category="Brännvin"
 	>
@@ -2853,7 +2853,7 @@
 	<song
 		name="Hyllningsvisa till Absinthen"
 		id="87"
-		author="Sing-Sing Singers, 2000"
+		author="Sing-Sing Singers (KTH, 2000)"
 		melody="O come all ye faithful"
 		category="Brännvin"
 	>
@@ -2881,7 +2881,7 @@
 	<song
 		name="Man kan dricka vatten"
 		id="88"
-		author="Datas nØllespex, 1995"
+		author="(Datas nØllespex, KTH, 1995)"
 		melody="Vi äro musikanter"
 		category="Brännvin"
 	>
@@ -2929,7 +2929,7 @@
 	<song
 		name="Ode till halvan"
 		id="90"
-		author="Torgny, 1936"
+		author="Torgny (1936)"
 		composer="Otto Lindblad"
 		melody="Längtan till landet"
 		category="Brännvin"
@@ -2973,7 +2973,7 @@
 	<song
 		name="Regalskeppet Vasa"
 		id="153"
-		author="Den Kongliga INviten"
+		author="Den Kongliga invITen (KTH)"
 		composer="Leigh Harline"
 		melody="Ser du stjärnan i det blå"
 		category="Brännvin"
@@ -3116,9 +3116,11 @@
 		</p>
 	</song>
 	<song
-		name="FESTU:s punschvisa"
+		name="FestU:s punschvisa"
 		id="94"
-		melody="Tomtarnas vinternatt"
+		author="FestU (Chalmers)"
+		composer="Vilhelm Sefve-Svensson"
+		melody="Tomtarnas julnatt"
 		category="Punsch"
 	>
 		<p>
@@ -3335,6 +3337,7 @@
 	<song
 		name="P.U.S.S.:s punschvisa"
 		id="105"
+		author="P.U.S.S."
 		composer="Tommy Nilsson"
 		melody="Öppna din dörr"
 		category="Punsch"
@@ -3435,7 +3438,7 @@
 	<song
 		name="När kaffet är serverat"
 		id="108"
-		author="Sångarstriden Lund, 1987"
+		author="(Sångarstriden, Lund, 1987)"
 		composer="Christian Hartmann"
 		melody="Mössens julafton"
 		category="Punsch"
@@ -3487,7 +3490,7 @@
 	<song
 		name="Härlig är punschen"
 		id="110"
-		author="Juristspexet Ansgar, 2003"
+		author="(Juristspexet Ansgar, 2003)"
 		melody="Nu grönskar det"
 		category="Punsch"
 	>
@@ -3515,7 +3518,7 @@
 	<song
 		name="Nu blotas det"
 		id="111"
-		author="Juristspexet Ansgar, 2003"
+		author="(Juristspexet Ansgar, 2003)"
 		composer="Johann Sebastian Bac"
 		melody="Nu grönskar det"
 		category="Punsch"
@@ -3544,7 +3547,7 @@
 	<song
 		name="Imperial punsch"
 		id="112"
-		author="DKM, 2000"
+		author="DKM (KTH, 2000)"
 		composer="John Williams"
 		melody="Imperial march, Star Wars"
 		category="Punsch"
@@ -3604,6 +3607,7 @@
 	<song
 		name="Sveriges arraktionalhymn"
 		id="152"
+		author="(Ekonomspexet Erik XIV, Stockholms universitet, 1992)"
 		melody="Du gamla, du fria"
 		category="Punsch"
 	>
@@ -3639,7 +3643,7 @@
 	<song
 		name="I Love Punsch"
 		id="159"
-		author="Samuel Larsson (2020)"
+		author="Samuel Larsson, IT (KTH, 2020)"
 		composer="Ben Oakland and Milton Drake"
 		melody="Java Jive"
 		category="Punsch"
@@ -4094,7 +4098,8 @@
 	<song
 		name="My heart will go on"
 		id="120"
-		author="Celine Dion"
+		author="Celine Dion (1997)"
+		composer="James Horner"
 		category="Utländskt"
 	>
 		<p>
@@ -4296,7 +4301,7 @@
 	<song
 		name="Man ska ha Linux"
 		id="125"
-		author="Erik Rålenius"
+		author="Erik Rålenius, IT (KTH)"
 		composer="Claes Eriksson"
 		melody="Man ska ha husvagn"
 		category="Nördigt"
@@ -4361,7 +4366,7 @@
 	<song
 		name="Om Emacs"
 		id="126"
-		author="Ingemar Ragnemalm"
+		author="Ingemar Ragnemalm (LiU)"
 		melody="Kovan kommer, kovan går"
 		category="Nördigt"
 	>
@@ -4394,7 +4399,7 @@
 		name="Ostkaka"
 		id="127"
 		composer="Jeremy Soule"
-		melody="Dovahkin, Skyrim theme"
+		melody="Dovahkin (Skyrim theme)"
 		category="Nördigt"
 	>
 		<p>
@@ -4422,7 +4427,7 @@
 	<song
 		name="Jag kan lära dig C"
 		id="160"
-		author="Arian och Sixten (DISK KM), DISK KM:s julfest 2011"
+		author="Arian och Sixten (DISK KM:s julfest, Stockholms universitet, 2011)"
 		composer="Alan Menken"
 		melody="A Whole New World"
 		category="Nördigt"
@@ -4454,7 +4459,7 @@
 	<song
 		name="Write in C"
 		id="161"
-		author="Jay Piecora, SUNY Binghamton"
+		author="Jay Piecora (SUNY Binghamton)"
 		composer="John Lennon, Paul McCartney"
 		melody="Let It Be"
 		category="Nördigt"
@@ -4503,7 +4508,7 @@
 	<song
 		name="Pop opp i topp"
 		id="128"
-		author="Thore Skogman, 1965"
+		author="Thore Skogman (1965)"
 		category="Esoterica"
 	>
 		<p>
@@ -4563,7 +4568,7 @@
 	<song
 		name="PRAOs visa"
 		id="129"
-		author="Niklas Söderlund och Wilhelm Svenselius"
+		author="Niklas Söderlund och Wilhelm Svenselius, IT-03 (KTH)"
 		melody="När månen vandrar"
 		category="Esoterica"
 	>
@@ -4581,7 +4586,7 @@
 	<song
 		name="Vår flygpilot"
 		id="130"
-		author="Dain Nilsson"
+		author="Dain Nilsson, IT-04 (KTH)"
 		melody="Oh Tannenbaum"
 		category="Esoterica"
 	>
@@ -4597,7 +4602,7 @@
 	<song
 		name="Farväl till IT-sektionen"
 		id="131"
-		author="Dain Nilsson och Erik Rålenius"
+		author="Dain Nilsson, IT-04, och Erik Rålenius, IT (KTH)"
 		melody="Uti vår hage"
 		category="Esoterica"
 	>
@@ -4632,7 +4637,7 @@
 	<song
 		name="IN-sektionen"
 		id="132"
-		author="Dain Nilsson och Erik Rålenius"
+		author="Dain Nilsson, IT-04, och Erik Rålenius, IT (KTH)"
 		composer="Aleksander Aleksandrov"
 		melody="Rysslands nationalsång"
 		category="Esoterica"
@@ -4655,7 +4660,7 @@
 	<song
 		name="Faddersången 2001"
 		id="133"
-		author="Kjell Ahlström"
+		author="Kjell Ahlström (KTH, 2001)"
 		composer="Elizabeth Cotten"
 		melody="SJ, SJ, gamle vän"
 		category="Esoterica"
@@ -4684,15 +4689,12 @@
 			Bron den utgör gränsens strand
 			till farligt ghettoland.
 		</p>
-		<comment>
-			Den sista versen delades ut på separata lappar i bussen och skall därför betraktas
-			som inofficiell.
-		</comment>
+		<comment>Den sista versen delades ut på separata lappar i bussen och skall därför betraktas som inofficiell.</comment>
 	</song>
 	<song
 		name="Läs inte på Handels"
 		id="134"
-		author="Alex Ellgren och Oscar Frick"
+		author="Alex Ellgren, ME-07, och Oscar Frick, ME-07 (KTH)"
 		category="Esoterica"
 	>
 		<p>
@@ -4820,7 +4822,7 @@
 	<song
 		name="Sång till Stor-MUX"
 		id="136"
-		author="Erik Lundberg och Wilhelm Svenselius"
+		author="Erik Lundberg och Wilhelm Svenselius, IT-03 (KTH)"
 		melody="Balladen om Theobald Thor"
 		category="Esoterica"
 	>
@@ -4885,7 +4887,7 @@
 	<song
 		name="Bacchivisan"
 		id="137"
-		author="Kjell Ahlström"
+		author="Kjell Ahlström (KTH)"
 		melody="Agadoo (ungefär)"
 		category="Esoterica"
 	>
@@ -4978,7 +4980,7 @@
 	<song
 		name="Tentavakten"
 		id="138"
-		author="Erik Rålenius"
+		author="Erik Rålenius, IT (KTH)"
 		melody="Du gamla, du fria"
 		category="Esoterica"
 	>
@@ -5001,7 +5003,7 @@
 	<song
 		name="Vart tog den schlema lilla nØllan vägen?"
 		id="139"
-		author="Kjell Ahlström"
+		author="Kjell Ahlström (KTH)"
 		melody="Vart tog den söta lilla flickan vägen"
 		category="Esoterica"
 	>
@@ -5092,7 +5094,7 @@
 	<song
 		name="Starke Arvid"
 		id="140"
-		author="Ola, Frukt och Flingor, 1979"
+		author="Ola, Frukt och Flingor (1979)"
 		category="Esoterica"
 	>
 		<p>
@@ -5146,7 +5148,7 @@
 	<song
 		name="Man ska gå ME"
 		id="141"
-		author="Viktor Åberg"
+		author="Viktor Åberg (KTH)"
 		composer="Claes Eriksson"
 		melody="Man ska ha husvagn"
 		category="Esoterica"
@@ -5196,7 +5198,7 @@
 	<song
 		name="Osqvik"
 		id="143"
-		author="Strängteoretiquerna, 2015"
+		author="Strängteoretiquerna, IT (KTH, 2015)"
 		melody="Vi äro musikanter"
 		category="Esoterica"
 	>
@@ -5284,7 +5286,7 @@
 	<song
 		name="invITensången"
 		id="146"
-		author="Daniel Byström"
+		author="Daniel Byström (KTH)"
 		composer="Otto Lindblad"
 		melody="Kungssången"
 		category="Högtidligt"
@@ -5313,7 +5315,7 @@
 	<song
 		name="Kungssången"
 		id="147"
-		author="C.V.A.Strandberg och Otto Lindblad, 1844"
+		author="C.V.A.Strandberg och Otto Lindblad (1844)"
 		category="Högtidligt"
 	>
 		<p>
@@ -5331,7 +5333,7 @@
 	<song
 		name="Stockholm i mitt hjärta"
 		id="148"
-		author="Lasse Berghagen"
+		author="Lasse Berghagen (1995)"
 		category="Högtidligt"
 	>
 		<p>
@@ -5380,7 +5382,7 @@
 	<song
 		name="Du gamla, du fria"
 		id="149"
-		author="Richard Dybeck, 1844"
+		author="Richard Dybeck (1844)"
 		category="Högtidligt"
 	>
 		<p>
@@ -5401,8 +5403,8 @@
 	<song
 		name="O, gamla klang- och jubeltid!"
 		id="150"
-		author="August Lindh, 1921"
-		composer="Eugen Höfling, 1825"
+		author="August Lindh (Juvenalorden, Uppsala, 1921)"
+		composer="Eugen Höfling (1825)"
 		melody="O alte Burschenherrlichkeit"
 		category="Högtidligt"
 	>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "in-song-list",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"main": "index.js",
 	"license": "MIT",
 	"scripts": {

--- a/songs/0_Moder_Kista.md
+++ b/songs/0_Moder_Kista.md
@@ -1,6 +1,12 @@
 ---
 title: Moder Kista
-author: David Larsson, IT00
+author: [
+	{
+		name: 'David Larsson, IT-00',
+		location: KTH,
+		year: 2000
+	}
+]
 melody: Längtan till landet
 composer: Otto Lindblad
 tags: [gasque, swe]

--- a/songs/0_Moder_Kista.md
+++ b/songs/0_Moder_Kista.md
@@ -1,12 +1,10 @@
 ---
 title: Moder Kista
-author: [
-	{
-		name: 'David Larsson, IT-00',
-		location: KTH,
-		year: 2000
-	}
-]
+author:
+  - name: David Larsson, IT-00
+    event: IT-nØllningen
+    location: KTH
+    year: 2000
 melody: Längtan till landet
 composer: Otto Lindblad
 tags: [gasque, swe]

--- a/songs/105_PUSSs_punschvisa.md
+++ b/songs/105_PUSSs_punschvisa.md
@@ -1,5 +1,10 @@
 ---
 title: P.U.S.S.:s punschvisa
+author: [
+	{
+		name: P.U.S.S.
+	}
+]
 melody: Öppna din dörr
 composer: Tommy Nilsson
 tags: [punsch, swe]

--- a/songs/105_PUSSs_punschvisa.md
+++ b/songs/105_PUSSs_punschvisa.md
@@ -1,10 +1,7 @@
 ---
 title: P.U.S.S.:s punschvisa
-author: [
-	{
-		name: P.U.S.S.
-	}
-]
+author:
+  - name: P.U.S.S.
 melody: Öppna din dörr
 composer: Tommy Nilsson
 tags: [punsch, swe]

--- a/songs/108_Nar_kaffet_ar_serverat.md
+++ b/songs/108_Nar_kaffet_ar_serverat.md
@@ -1,6 +1,12 @@
 ---
 title: När kaffet är serverat
-author: Sångarstriden Lund, 1987
+author: [
+	{
+		event: Sångarstriden,
+		location: Lund, 
+		year: 1987
+	}
+]
 melody: Mössens julafton
 composer: Christian Hartmann
 tags: [punsch, swe]

--- a/songs/108_Nar_kaffet_ar_serverat.md
+++ b/songs/108_Nar_kaffet_ar_serverat.md
@@ -1,12 +1,9 @@
 ---
 title: När kaffet är serverat
-author: [
-	{
-		event: Sångarstriden,
-		location: Lund, 
-		year: 1987
-	}
-]
+author:
+  - event: Sångarstriden
+    location: Lund
+    year: 1987
 melody: Mössens julafton
 composer: Christian Hartmann
 tags: [punsch, swe]

--- a/songs/10_Jag_har_aldrig.md
+++ b/songs/10_Jag_har_aldrig.md
@@ -1,8 +1,27 @@
 ---
 title: Jag har aldrig...
-author: (Handelsvisan) Team Kangaroo, 1977; (Fysikvisan) DKM, 2000; (Datavisan) Mattis Castegren, 2001
-melody: O hur saligt att få vandra
-composer: Joël Blomqvist och Per Ollén
+author: [
+	{
+		name: 'Team Kangaroo, F',
+		event: Gerhards-gasque,
+		location: KTH,
+		year: 1977,
+		comment: Handelsvisan
+	}, {
+		name: DKM,
+		location: KTH,
+		year: 2000,
+		comment: Fysikvisan
+	}, {
+		name: Mattis Castegren,
+		event: Fysiksektionens Ettans fest,
+		location: KTH,
+		year: 2001,
+		comment: Datavisan
+	}
+]
+melody: O, hur saligt att få vandra
+composer: Robert Lowry
 tags: [gasque, swe]
 ---
 

--- a/songs/10_Jag_har_aldrig.md
+++ b/songs/10_Jag_har_aldrig.md
@@ -1,25 +1,20 @@
 ---
 title: Jag har aldrig...
-author: [
-	{
-		name: 'Team Kangaroo, F',
-		event: Gerhards-gasque,
-		location: KTH,
-		year: 1977,
-		comment: Handelsvisan
-	}, {
-		name: DKM,
-		location: KTH,
-		year: 2000,
-		comment: Fysikvisan
-	}, {
-		name: Mattis Castegren,
-		event: Fysiksektionens Ettans fest,
-		location: KTH,
-		year: 2001,
-		comment: Datavisan
-	}
-]
+author:
+  - name: Team Kangaroo, F
+    event: Gerhards-gasque
+    location: KTH
+    year: 1977
+    comment: Handelsvisan
+  - name: DKM
+    location: KTH
+    year: 2000
+    comment: Fysikvisan
+  - name: Mattis Castegren
+    event: Fysiksektionens Ettans fest
+    location: KTH
+    year: 2001
+    comment: Datavisan
 melody: O, hur saligt att få vandra
 composer: Robert Lowry
 tags: [gasque, swe]

--- a/songs/110_Harlig_ar_punschen.md
+++ b/songs/110_Harlig_ar_punschen.md
@@ -1,6 +1,11 @@
 ---
 title: Härlig är punschen
-author: Juristspexet Ansgar, 2003
+author: [
+	{
+		event: Juristspexet Ansgar,
+		year: 2003
+	}
+]
 melody: Nu grönskar det
 tags: [punsch, swe]
 ---

--- a/songs/110_Harlig_ar_punschen.md
+++ b/songs/110_Harlig_ar_punschen.md
@@ -1,12 +1,10 @@
 ---
 title: Härlig är punschen
-author: [
-	{
-		event: Juristspexet Ansgar,
-		year: 2003
-	}
-]
+author:
+  - event: Juristspexet Ansgar
+    year: 2003
 melody: Nu grönskar det
+composer: Johann Sebastian Bach
 tags: [punsch, swe]
 ---
 

--- a/songs/111_Nu_blotas_det.md
+++ b/songs/111_Nu_blotas_det.md
@@ -1,13 +1,10 @@
 ---
 title: Nu blotas det
-author: [
-	{
-		event: Juristspexet Ansgar,
-		year: 2003
-	}
-]
+author:
+  - event: Juristspexet Ansgar
+    year: 2003
 melody: Nu grönskar det
-composer: Johann Sebastian Bac
+composer: Johann Sebastian Bach
 tags: [punsch, swe]
 ---
 

--- a/songs/111_Nu_blotas_det.md
+++ b/songs/111_Nu_blotas_det.md
@@ -1,6 +1,11 @@
 ---
 title: Nu blotas det
-author: Juristspexet Ansgar, 2003
+author: [
+	{
+		event: Juristspexet Ansgar,
+		year: 2003
+	}
+]
 melody: Nu grönskar det
 composer: Johann Sebastian Bac
 tags: [punsch, swe]

--- a/songs/112_Imperial_punsch.md
+++ b/songs/112_Imperial_punsch.md
@@ -1,6 +1,12 @@
 ---
 title: Imperial punsch
-author: DKM, 2000
+author: [
+	{
+		name: DKM,
+		location: KTH,
+		year: 2000
+	}
+]
 melody: Imperial march, Star Wars
 composer: John Williams
 tags: [punsch, swe]

--- a/songs/112_Imperial_punsch.md
+++ b/songs/112_Imperial_punsch.md
@@ -1,13 +1,10 @@
 ---
 title: Imperial punsch
-author: [
-	{
-		name: DKM,
-		location: KTH,
-		year: 2000
-	}
-]
-melody: Imperial march, Star Wars
+author:
+  - name: DKM
+    location: KTH
+    year: 2000
+melody: Imperial march (Star Wars)
 composer: John Williams
 tags: [punsch, swe]
 ---

--- a/songs/113_Arrak.md
+++ b/songs/113_Arrak.md
@@ -1,6 +1,10 @@
 ---
 title: Arrak
-author: André Mabande
+author: [
+	{
+		name: André Mabande
+	}
+]
 melody: Only you
 tags: [punsch, swe]
 ---

--- a/songs/113_Arrak.md
+++ b/songs/113_Arrak.md
@@ -1,10 +1,7 @@
 ---
 title: Arrak
-author: [
-	{
-		name: André Mabande
-	}
-]
+author:
+  - name: André Mabande
 melody: Only you
 tags: [punsch, swe]
 ---

--- a/songs/114_Barretts_Privateers.md
+++ b/songs/114_Barretts_Privateers.md
@@ -1,10 +1,8 @@
 ---
 title: Barrett's Privateers
-author: [
-	{
-		name: Stan Rogers
-	}
-]
+author:
+  - name: Stan Rogers
+    year: 1976
 tags: [foreign, eng]
 ---
 

--- a/songs/114_Barretts_Privateers.md
+++ b/songs/114_Barretts_Privateers.md
@@ -1,6 +1,10 @@
 ---
 title: Barrett's Privateers
-author: Stan Rogers
+author: [
+	{
+		name: Stan Rogers
+	}
+]
 tags: [foreign, eng]
 ---
 

--- a/songs/11_Jag_var_full_en_gang.md
+++ b/songs/11_Jag_var_full_en_gang.md
@@ -1,7 +1,7 @@
 ---
 title: Jag var full en gång...
 melody: Flottarkärlek
-composer: Hugo Lindh, Gösta 'Snoddas' Nordgren
+composer: Hugo Lindh, Gösta "Snoddas" Nordgren
 tags: [gasque, swe]
 ---
 

--- a/songs/120_My_heart_will_go_on.md
+++ b/songs/120_My_heart_will_go_on.md
@@ -1,11 +1,8 @@
 ---
 title: My heart will go on
-author: [
-	{
-		name: Celine Dion,
-		year: 1997
-	}
-]
+author:
+  - name: Celine Dion
+    year: 1997
 composer: James Horner
 tags: [foreign, eng]
 ---

--- a/songs/120_My_heart_will_go_on.md
+++ b/songs/120_My_heart_will_go_on.md
@@ -1,6 +1,12 @@
 ---
 title: My heart will go on
-author: Celine Dion
+author: [
+	{
+		name: Celine Dion,
+		year: 1997
+	}
+]
+composer: James Horner
 tags: [foreign, eng]
 ---
 

--- a/songs/121_In_the_trade_of_jester.md
+++ b/songs/121_In_the_trade_of_jester.md
@@ -1,10 +1,7 @@
 ---
 title: In the trade of jester
-author: [
-	{
-		name: Jauvet
-	}
-]
+author:
+  - name: Jauvet
 tags: [foreign, eng]
 ---
 

--- a/songs/121_In_the_trade_of_jester.md
+++ b/songs/121_In_the_trade_of_jester.md
@@ -1,6 +1,10 @@
 ---
 title: In the trade of jester
-author: Jauvet
+author: [
+	{
+		name: Jauvet
+	}
+]
 tags: [foreign, eng]
 ---
 

--- a/songs/124_Unix_Man.md
+++ b/songs/124_Unix_Man.md
@@ -1,6 +1,10 @@
 ---
 title: Unix Man
-author: Bran Morrison
+author: [
+	{
+		name: Bran Morrison
+	}
+]
 melody: Nowhere Man
 composer: John Lennon and Paul McCartney
 tags: [nerdy, eng]

--- a/songs/124_Unix_Man.md
+++ b/songs/124_Unix_Man.md
@@ -1,10 +1,7 @@
 ---
 title: Unix Man
-author: [
-	{
-		name: Bran Morrison
-	}
-]
+author:
+  - name: Brad Morrison
 melody: Nowhere Man
 composer: John Lennon and Paul McCartney
 tags: [nerdy, eng]

--- a/songs/125_Man_ska_ha_Linux.md
+++ b/songs/125_Man_ska_ha_Linux.md
@@ -1,6 +1,11 @@
 ---
 title: Man ska ha Linux
-author: Erik Rålenius
+author: [
+	{
+		name: 'Erik Rålenius, IT',
+		location: KTH
+	}
+]
 melody: Man ska ha husvagn
 composer: Claes Eriksson
 tags: [nerdy, swe]

--- a/songs/125_Man_ska_ha_Linux.md
+++ b/songs/125_Man_ska_ha_Linux.md
@@ -1,11 +1,8 @@
 ---
 title: Man ska ha Linux
-author: [
-	{
-		name: 'Erik Rålenius, IT',
-		location: KTH
-	}
-]
+author:
+  - name: Erik Rålenius, IT
+    location: KTH
 melody: Man ska ha husvagn
 composer: Claes Eriksson
 tags: [nerdy, swe]

--- a/songs/126_Om_Emacs.md
+++ b/songs/126_Om_Emacs.md
@@ -1,11 +1,8 @@
 ---
 title: Om Emacs
-author: [
-	{
-		name: Ingemar Ragnemalm,
-		location: LiU
-	}
-]
+author:
+  - name: Ingemar Ragnemalm
+    location: LiU
 melody: Kovan kommer, kovan går
 tags: [nerdy, swe]
 ---

--- a/songs/126_Om_Emacs.md
+++ b/songs/126_Om_Emacs.md
@@ -1,6 +1,11 @@
 ---
 title: Om Emacs
-author: Ingemar Ragnemalm
+author: [
+	{
+		name: Ingemar Ragnemalm,
+		location: LiU
+	}
+]
 melody: Kovan kommer, kovan går
 tags: [nerdy, swe]
 ---

--- a/songs/127_Ostkaka.md
+++ b/songs/127_Ostkaka.md
@@ -1,6 +1,6 @@
 ---
 title: Ostkaka
-melody: Dovahkin, Skyrim theme
+melody: Dovahkin (Skyrim theme)
 composer: Jeremy Soule
 tags: [nerdy, swe]
 ---

--- a/songs/128_Pop_opp_i_topp.md
+++ b/songs/128_Pop_opp_i_topp.md
@@ -1,11 +1,8 @@
 ---
 title: Pop opp i topp
-author: [
-	{
-		name: Thore Skogman,
-		year: 1965
-	}
-]
+author:
+  - name: Thore Skogman
+    year: 1965
 tags: [esoteric, swe]
 ---
 

--- a/songs/128_Pop_opp_i_topp.md
+++ b/songs/128_Pop_opp_i_topp.md
@@ -1,6 +1,11 @@
 ---
 title: Pop opp i topp
-author: Thore Skogman, 1965
+author: [
+	{
+		name: Thore Skogman,
+		year: 1965
+	}
+]
 tags: [esoteric, swe]
 ---
 

--- a/songs/129_PRAOs_visa.md
+++ b/songs/129_PRAOs_visa.md
@@ -1,6 +1,11 @@
 ---
 title: PRAOs visa
-author: Niklas Söderlund och Wilhelm Svenselius
+author: [
+	{
+		name: 'Niklas Söderlund och Wilhelm Svenselius, IT-03',
+		location: KTH
+	}
+]
 melody: När månen vandrar
 tags: [esoteric, swe]
 ---

--- a/songs/129_PRAOs_visa.md
+++ b/songs/129_PRAOs_visa.md
@@ -1,11 +1,8 @@
 ---
 title: PRAOs visa
-author: [
-	{
-		name: 'Niklas Söderlund och Wilhelm Svenselius, IT-03',
-		location: KTH
-	}
-]
+author:
+  - name: Niklas Söderlund och Wilhelm Svenselius, IT-03
+    location: KTH
 melody: När månen vandrar
 tags: [esoteric, swe]
 ---

--- a/songs/130_Var_flygpilot.md
+++ b/songs/130_Var_flygpilot.md
@@ -1,6 +1,11 @@
 ---
 title: Vår flygpilot
-author: Dain Nilsson
+author: [
+	{
+		name: 'Dain Nilsson, IT-04',
+		location: KTH
+	}
+]
 melody: Oh Tannenbaum
 tags: [esoteric, swe]
 ---

--- a/songs/130_Var_flygpilot.md
+++ b/songs/130_Var_flygpilot.md
@@ -1,11 +1,8 @@
 ---
 title: Vår flygpilot
-author: [
-	{
-		name: 'Dain Nilsson, IT-04',
-		location: KTH
-	}
-]
+author:
+  - name: Dain Nilsson, IT-04
+    location: KTH
 melody: Oh Tannenbaum
 tags: [esoteric, swe]
 ---

--- a/songs/131_Farval_till_ITsektionen.md
+++ b/songs/131_Farval_till_ITsektionen.md
@@ -1,6 +1,11 @@
 ---
 title: Farväl till IT-sektionen
-author: Dain Nilsson och Erik Rålenius
+author: [
+	{
+		name: 'Dain Nilsson, IT-04, och Erik Rålenius, IT',
+		location: KTH
+	}
+]
 melody: Uti vår hage
 tags: [esoteric, swe]
 ---

--- a/songs/131_Farval_till_ITsektionen.md
+++ b/songs/131_Farval_till_ITsektionen.md
@@ -1,11 +1,8 @@
 ---
 title: Farväl till IT-sektionen
-author: [
-	{
-		name: 'Dain Nilsson, IT-04, och Erik Rålenius, IT',
-		location: KTH
-	}
-]
+author:
+  - name: Dain Nilsson, IT-04, och Erik Rålenius, IT
+    location: KTH
 melody: Uti vår hage
 tags: [esoteric, swe]
 ---

--- a/songs/132_INsektionen.md
+++ b/songs/132_INsektionen.md
@@ -1,6 +1,11 @@
 ---
 title: IN-sektionen
-author: Dain Nilsson och Erik Rålenius
+author: [
+	{
+		name: 'Dain Nilsson, IT-04, och Erik Rålenius, IT',
+		location: KTH
+	}
+]
 melody: Rysslands nationalsång
 composer: Aleksander Aleksandrov
 tags: [esoteric, swe]

--- a/songs/132_INsektionen.md
+++ b/songs/132_INsektionen.md
@@ -1,11 +1,8 @@
 ---
 title: IN-sektionen
-author: [
-	{
-		name: 'Dain Nilsson, IT-04, och Erik Rålenius, IT',
-		location: KTH
-	}
-]
+author:
+  - name: Dain Nilsson, IT-04, och Erik Rålenius, IT
+    location: KTH
 melody: Rysslands nationalsång
 composer: Aleksander Aleksandrov
 tags: [esoteric, swe]

--- a/songs/133_Faddersangen_2001.md
+++ b/songs/133_Faddersangen_2001.md
@@ -1,12 +1,9 @@
 ---
 title: Faddersången 2001
-author: [
-	{
-		name: Kjell Ahlström,
-		location: KTH,
-		year: 2001
-	}
-]
+author:
+  - name: Kjell Ahlström
+    location: KTH
+    year: 2001
 melody: SJ, SJ, gamle vän
 composer: Elizabeth Cotten
 tags: [esoteric, swe]

--- a/songs/133_Faddersangen_2001.md
+++ b/songs/133_Faddersangen_2001.md
@@ -1,6 +1,12 @@
 ---
 title: Faddersången 2001
-author: Kjell Ahlström
+author: [
+	{
+		name: Kjell Ahlström,
+		location: KTH,
+		year: 2001
+	}
+]
 melody: SJ, SJ, gamle vän
 composer: Elizabeth Cotten
 tags: [esoteric, swe]
@@ -26,5 +32,4 @@ tydlig gräns är dess station.
 Bron den utgör gränsens strand
 till farligt ghettoland.
 
-> Den sista versen delades ut på separata lappar i bussen och skall därför betraktas
-> som inofficiell.
+> Den sista versen delades ut på separata lappar i bussen och skall därför betraktas som inofficiell.

--- a/songs/134_Las_inte_pa_Handels.md
+++ b/songs/134_Las_inte_pa_Handels.md
@@ -1,11 +1,8 @@
 ---
 title: Läs inte på Handels
-author: [
-	{
-		name: 'Alex Ellgren, ME-07, och Oscar Frick, ME-07',
-		location: KTH
-	}
-]
+author:
+  - name: Alex Ellgren, ME-07, och Oscar Frick, ME-07
+    location: KTH
 tags: [esoteric, swe]
 ---
 

--- a/songs/134_Las_inte_pa_Handels.md
+++ b/songs/134_Las_inte_pa_Handels.md
@@ -1,6 +1,11 @@
 ---
 title: Läs inte på Handels
-author: Alex Ellgren och Oscar Frick
+author: [
+	{
+		name: 'Alex Ellgren, ME-07, och Oscar Frick, ME-07',
+		location: KTH
+	}
+]
 tags: [esoteric, swe]
 ---
 

--- a/songs/135_Satansvisan.md
+++ b/songs/135_Satansvisan.md
@@ -1,6 +1,10 @@
 ---
 title: Satansvisan
-author: J. Strauss, Strauss ex Machina
+author: [
+	{
+		name: 'J. Strauss, Strauss ex Machina'
+	}
+]
 melody: Staffan var en stalledräng
 tags: [esoteric, swe]
 ---

--- a/songs/135_Satansvisan.md
+++ b/songs/135_Satansvisan.md
@@ -1,10 +1,7 @@
 ---
 title: Satansvisan
-author: [
-	{
-		name: 'J. Strauss, Strauss ex Machina'
-	}
-]
+author:
+  - name: J. Strauss, Strauss ex Machina
 melody: Staffan var en stalledräng
 tags: [esoteric, swe]
 ---

--- a/songs/136_Sang_till_StorMUX.md
+++ b/songs/136_Sang_till_StorMUX.md
@@ -1,6 +1,11 @@
 ---
 title: Sång till Stor-MUX
-author: Erik Lundberg och Wilhelm Svenselius
+author: [
+	{
+		name: 'Erik Lundberg och Wilhelm Svenselius, IT-03',
+		location: KTH
+	}
+]
 melody: Balladen om Theobald Thor
 tags: [esoteric, swe]
 ---

--- a/songs/136_Sang_till_StorMUX.md
+++ b/songs/136_Sang_till_StorMUX.md
@@ -1,12 +1,9 @@
 ---
 title: Sång till Stor-MUX
-author: [
-	{
-		name: 'Erik Lundberg och Wilhelm Svenselius, IT-03',
-		location: KTH
-	}
-]
-melody: Balladen om Theobald Thor
+author:
+  - name: Erik Lundberg och Wilhelm Svenselius, IT-03
+    location: KTH
+melody: The Ball of Kirriemuir (Balladen om Theobald Thor)
 tags: [esoteric, swe]
 ---
 

--- a/songs/137_Bacchivisan.md
+++ b/songs/137_Bacchivisan.md
@@ -1,6 +1,11 @@
 ---
 title: Bacchivisan
-author: Kjell Ahlström
+author: [
+	{
+		name: Kjell Ahlström,
+		location: KTH
+	}
+]
 melody: Agadoo (ungefär)
 tags: [esoteric, swe]
 ---

--- a/songs/137_Bacchivisan.md
+++ b/songs/137_Bacchivisan.md
@@ -1,11 +1,8 @@
 ---
 title: Bacchivisan
-author: [
-	{
-		name: Kjell Ahlström,
-		location: KTH
-	}
-]
+author:
+  - name: Kjell Ahlström
+    location: KTH
 melody: Agadoo (ungefär)
 tags: [esoteric, swe]
 ---

--- a/songs/138_Tentavakten.md
+++ b/songs/138_Tentavakten.md
@@ -1,6 +1,11 @@
 ---
 title: Tentavakten
-author: Erik Rålenius
+author: [
+	{
+		name: 'Erik Rålenius, IT',
+		location: KTH
+	}
+]
 melody: Du gamla, du fria
 tags: [esoteric, swe]
 ---

--- a/songs/138_Tentavakten.md
+++ b/songs/138_Tentavakten.md
@@ -1,11 +1,8 @@
 ---
 title: Tentavakten
-author: [
-	{
-		name: 'Erik Rålenius, IT',
-		location: KTH
-	}
-]
+author:
+  - name: Erik Rålenius, IT
+    location: KTH
 melody: Du gamla, du fria
 tags: [esoteric, swe]
 ---

--- a/songs/139_Vart_tog_den_schlema_lilla_nllan_vagen.md
+++ b/songs/139_Vart_tog_den_schlema_lilla_nllan_vagen.md
@@ -1,6 +1,11 @@
 ---
 title: Vart tog den schlema lilla nØllan vägen?
-author: Kjell Ahlström
+author: [
+	{
+		name: Kjell Ahlström,
+		location: KTH
+	}
+]
 melody: Vart tog den söta lilla flickan vägen
 tags: [esoteric, swe]
 ---

--- a/songs/139_Vart_tog_den_schlema_lilla_nllan_vagen.md
+++ b/songs/139_Vart_tog_den_schlema_lilla_nllan_vagen.md
@@ -1,11 +1,8 @@
 ---
 title: Vart tog den schlema lilla nØllan vägen?
-author: [
-	{
-		name: Kjell Ahlström,
-		location: KTH
-	}
-]
+author:
+  - name: Kjell Ahlström
+    location: KTH
 melody: Vart tog den söta lilla flickan vägen
 tags: [esoteric, swe]
 ---

--- a/songs/13_Lille_Olle.md
+++ b/songs/13_Lille_Olle.md
@@ -1,11 +1,8 @@
 ---
 title: Lille Olle
-author: [
-	{
-		name: 'Calle Isaksson, D',
-		location: LiTH
-	}
-]
+author:
+  - name: Calle Isaksson, D
+    location: LiTH
 melody: Katjuscha
 composer: Matvey Blanter
 tags: [gasque, swe]

--- a/songs/13_Lille_Olle.md
+++ b/songs/13_Lille_Olle.md
@@ -1,6 +1,11 @@
 ---
 title: Lille Olle
-author: Calle Isaksson, D-LiTH
+author: [
+	{
+		name: 'Calle Isaksson, D',
+		location: LiTH
+	}
+]
 melody: Katjuscha
 composer: Matvey Blanter
 tags: [gasque, swe]

--- a/songs/140_Starke_Arvid.md
+++ b/songs/140_Starke_Arvid.md
@@ -1,6 +1,11 @@
 ---
 title: Starke Arvid
-author: Ola, Frukt och Flingor, 1979
+author: [
+	{
+		name: 'Ola, Frukt och Flingor',
+		year: 1979
+	}
+]
 tags: [esoteric, swe]
 ---
 

--- a/songs/140_Starke_Arvid.md
+++ b/songs/140_Starke_Arvid.md
@@ -1,11 +1,8 @@
 ---
 title: Starke Arvid
-author: [
-	{
-		name: 'Ola, Frukt och Flingor',
-		year: 1979
-	}
-]
+author:
+  - name: Ola, Frukt och Flingor
+    year: 1979
 tags: [esoteric, swe]
 ---
 

--- a/songs/141_Man_ska_ga_ME.md
+++ b/songs/141_Man_ska_ga_ME.md
@@ -1,6 +1,11 @@
 ---
 title: Man ska gå ME
-author: Viktor Åberg
+author: [
+	{
+		name: Viktor Åberg,
+		location: KTH
+	}
+]
 melody: Man ska ha husvagn
 composer: Claes Eriksson
 tags: [esoteric, swe]

--- a/songs/141_Man_ska_ga_ME.md
+++ b/songs/141_Man_ska_ga_ME.md
@@ -1,11 +1,8 @@
 ---
 title: Man ska gå ME
-author: [
-	{
-		name: Viktor Åberg,
-		location: KTH
-	}
-]
+author:
+  - name: Viktor Åberg
+    location: KTH
 melody: Man ska ha husvagn
 composer: Claes Eriksson
 tags: [esoteric, swe]

--- a/songs/143_Osqvik.md
+++ b/songs/143_Osqvik.md
@@ -1,12 +1,9 @@
 ---
 title: Osqvik
-author: [
-	{
-		name: 'Strängteoretiquerna, IT',
-		location: KTH,
-		year: 2015
-	}
-]
+author:
+  - name: Strängteoretiquerna, IT
+    location: KTH
+    year: 2015
 melody: Vi äro musikanter
 tags: [esoteric, swe]
 ---

--- a/songs/143_Osqvik.md
+++ b/songs/143_Osqvik.md
@@ -1,6 +1,12 @@
 ---
 title: Osqvik
-author: Strängteoretiquerna, 2015
+author: [
+	{
+		name: 'Strängteoretiquerna, IT',
+		location: KTH,
+		year: 2015
+	}
+]
 melody: Vi äro musikanter
 tags: [esoteric, swe]
 ---

--- a/songs/143_Osqvik.md
+++ b/songs/143_Osqvik.md
@@ -1,7 +1,7 @@
 ---
 title: Osqvik
 author:
-  - name: Strängteoretiquerna, IT
+  - name: Strängteoretiquerna, IN
     location: KTH
     year: 2015
 melody: Vi äro musikanter

--- a/songs/146_invITensangen.md
+++ b/songs/146_invITensangen.md
@@ -1,6 +1,11 @@
 ---
 title: invITensången
-author: Daniel Byström
+author: [
+	{
+		name: Daniel Byström,
+		location: KTH
+	}
+]
 melody: Kungssången
 composer: Otto Lindblad
 tags: [solemn, swe]

--- a/songs/146_invITensangen.md
+++ b/songs/146_invITensangen.md
@@ -1,11 +1,8 @@
 ---
 title: invITensången
-author: [
-	{
-		name: Daniel Byström,
-		location: KTH
-	}
-]
+author:
+  - name: Daniel Byström
+    location: KTH
 melody: Kungssången
 composer: Otto Lindblad
 tags: [solemn, swe]

--- a/songs/147_Kungssangen.md
+++ b/songs/147_Kungssangen.md
@@ -1,8 +1,11 @@
 ---
 title: Kungssången
 author:
-  - name: C.V.A.Strandberg och Otto Lindblad
+  - name: C.V.A.Strandberg
+    event: Firande av Oscar I:s tronbestigning
+    location: Lunds universitet
     year: 1844
+composer: Otto Lindblad
 tags: [solemn, swe]
 ---
 

--- a/songs/147_Kungssangen.md
+++ b/songs/147_Kungssangen.md
@@ -1,6 +1,11 @@
 ---
 title: Kungssången
-author: C.V.A.Strandberg och Otto Lindblad, 1844
+author: [
+	{
+		name: C.V.A.Strandberg och Otto Lindblad,
+		year: 1844
+	}
+]
 tags: [solemn, swe]
 ---
 

--- a/songs/147_Kungssangen.md
+++ b/songs/147_Kungssangen.md
@@ -1,11 +1,8 @@
 ---
 title: Kungssången
-author: [
-	{
-		name: C.V.A.Strandberg och Otto Lindblad,
-		year: 1844
-	}
-]
+author:
+  - name: C.V.A.Strandberg och Otto Lindblad
+    year: 1844
 tags: [solemn, swe]
 ---
 

--- a/songs/148_Stockholm_i_mitt_hjarta.md
+++ b/songs/148_Stockholm_i_mitt_hjarta.md
@@ -1,6 +1,11 @@
 ---
 title: Stockholm i mitt hjärta
-author: Lasse Berghagen
+author: [
+	{
+		name: Lasse Berghagen,
+		year: 1995
+	}
+]
 tags: [solemn, swe]
 ---
 

--- a/songs/148_Stockholm_i_mitt_hjarta.md
+++ b/songs/148_Stockholm_i_mitt_hjarta.md
@@ -1,11 +1,8 @@
 ---
 title: Stockholm i mitt hjärta
-author: [
-	{
-		name: Lasse Berghagen,
-		year: 1995
-	}
-]
+author:
+  - name: Lasse Berghagen
+    year: 1995
 tags: [solemn, swe]
 ---
 

--- a/songs/149_Du_gamla_du_fria.md
+++ b/songs/149_Du_gamla_du_fria.md
@@ -1,6 +1,11 @@
 ---
 title: Du gamla, du fria
-author: Richard Dybeck, 1844
+author: [
+	{
+		name: Richard Dybeck,
+		year: 1844
+	}
+]
 tags: [solemn, swe]
 ---
 

--- a/songs/149_Du_gamla_du_fria.md
+++ b/songs/149_Du_gamla_du_fria.md
@@ -1,11 +1,8 @@
 ---
 title: Du gamla, du fria
-author: [
-	{
-		name: Richard Dybeck,
-		year: 1844
-	}
-]
+author:
+  - name: Richard Dybeck
+    year: 1844
 tags: [solemn, swe]
 ---
 

--- a/songs/150_O_gamla_klang_och_jubeltid.md
+++ b/songs/150_O_gamla_klang_och_jubeltid.md
@@ -1,8 +1,15 @@
 ---
 title: O, gamla klang- och jubeltid!
-author: August Lindh, 1921
+author: [
+	{
+		name: August Lindh,
+		event: Juvenalorden,
+		location: Uppsala,
+		year: 1921
+	}
+]
 melody: O alte Burschenherrlichkeit
-composer: Eugen Höfling, 1825
+composer: Eugen Höfling (1825)
 tags: [solemn, swe]
 ---
 

--- a/songs/150_O_gamla_klang_och_jubeltid.md
+++ b/songs/150_O_gamla_klang_och_jubeltid.md
@@ -1,13 +1,10 @@
 ---
 title: O, gamla klang- och jubeltid!
-author: [
-	{
-		name: August Lindh,
-		event: Juvenalorden,
-		location: Uppsala,
-		year: 1921
-	}
-]
+author:
+  - name: August Lindh
+    event: Juvenalorden
+    location: Uppsala
+    year: 1921
 melody: O alte Burschenherrlichkeit
 composer: Eugen Höfling (1825)
 tags: [solemn, swe]

--- a/songs/152_Sveriges_arraktionalhymn.md
+++ b/songs/152_Sveriges_arraktionalhymn.md
@@ -1,12 +1,9 @@
 ---
 title: Sveriges arraktionalhymn
-author: [
-	{
-		event: Ekonomspexet Erik XIV,
-		location: Stockholms universitet,
-		year: 1992
-	}
-]
+author:
+  - event: Ekonomspexet Erik XIV
+    location: Stockholms universitet
+    year: 1992
 melody: Du gamla, du fria
 tags: [punsch, swe]
 ---

--- a/songs/152_Sveriges_arraktionalhymn.md
+++ b/songs/152_Sveriges_arraktionalhymn.md
@@ -1,8 +1,13 @@
 ---
 title: Sveriges arraktionalhymn
-author:
+author: [
+	{
+		event: Ekonomspexet Erik XIV,
+		location: Stockholms universitet,
+		year: 1992
+	}
+]
 melody: Du gamla, du fria
-composer:
 tags: [punsch, swe]
 ---
 

--- a/songs/153_Regalskeppet_Vasa.md
+++ b/songs/153_Regalskeppet_Vasa.md
@@ -1,11 +1,8 @@
 ---
 title: Regalskeppet Vasa
-author: [
-	{
-		name: Den Kongliga invITen,
-		location: KTH
-	}
-]
+author:
+  - name: Den Kongliga invITen
+    location: KTH
 melody: Ser du stjärnan i det blå
 composer: Leigh Harline
 tags: [snaps, swe]

--- a/songs/153_Regalskeppet_Vasa.md
+++ b/songs/153_Regalskeppet_Vasa.md
@@ -1,6 +1,11 @@
 ---
 title: Regalskeppet Vasa
-author: Den Kongliga INviten
+author: [
+	{
+		name: Den Kongliga invITen,
+		location: KTH
+	}
+]
 melody: Ser du stjärnan i det blå
 composer: Leigh Harline
 tags: [snaps, swe]

--- a/songs/154_Viking_Raiders.md
+++ b/songs/154_Viking_Raiders.md
@@ -1,12 +1,9 @@
 ---
 title: Viking Raiders
-author: [
-	{
-		name: 'Samuel Larsson, IT',
-		location: KTH,
-		year: 2020
-	}
-]
+author:
+  - name: Samuel Larsson, IT-17
+    location: KTH
+    year: 2020
 melody: Spanish Ladies
 tags: [gasque, eng]
 ---

--- a/songs/154_Viking_Raiders.md
+++ b/songs/154_Viking_Raiders.md
@@ -1,6 +1,12 @@
 ---
 title: Viking Raiders
-author: Samuel Larsson (2020)
+author: [
+	{
+		name: 'Samuel Larsson, IT',
+		location: KTH,
+		year: 2020
+	}
+]
 melody: Spanish Ladies
 tags: [gasque, eng]
 ---

--- a/songs/154_Viking_Raiders.md
+++ b/songs/154_Viking_Raiders.md
@@ -1,7 +1,7 @@
 ---
 title: Viking Raiders
 author:
-  - name: Samuel Larsson, IT-17
+  - name: Samuel Larsson, IN-17
     location: KTH
     year: 2020
 melody: Spanish Ladies

--- a/songs/159_I_Love_Punsch.md
+++ b/songs/159_I_Love_Punsch.md
@@ -1,7 +1,7 @@
 ---
 title: I Love Punsch
 author:
-  - name: Samuel Larsson, IT-17
+  - name: Samuel Larsson, IN-17
     location: KTH
     year: 2020
 melody: Java Jive

--- a/songs/159_I_Love_Punsch.md
+++ b/songs/159_I_Love_Punsch.md
@@ -1,12 +1,9 @@
 ---
 title: I Love Punsch
-author: [
-	{
-		name: 'Samuel Larsson, IT',
-		location: KTH,
-		year: 2020
-	}
-]
+author:
+  - name: Samuel Larsson, IT-17
+    location: KTH
+    year: 2020
 melody: Java Jive
 composer: Ben Oakland and Milton Drake
 tags: [punsch, eng]

--- a/songs/159_I_Love_Punsch.md
+++ b/songs/159_I_Love_Punsch.md
@@ -1,6 +1,12 @@
 ---
 title: I Love Punsch
-author: Samuel Larsson (2020)
+author: [
+	{
+		name: 'Samuel Larsson, IT',
+		location: KTH,
+		year: 2020
+	}
+]
 melody: Java Jive
 composer: Ben Oakland and Milton Drake
 tags: [punsch, eng]

--- a/songs/15_Nar_jag_ar_fuller.md
+++ b/songs/15_Nar_jag_ar_fuller.md
@@ -1,6 +1,13 @@
 ---
 title: När jag är fuller
-author: Sångartäflan, 1942
+author: [
+	{
+		name: "Tore 'Pekka' Norén, B",
+		event: Sångartäflan,
+		location: KTH,
+		year: 1942
+	}
+]
 melody: När månen vandrar
 tags: [gasque, swe]
 ---

--- a/songs/15_Nar_jag_ar_fuller.md
+++ b/songs/15_Nar_jag_ar_fuller.md
@@ -1,13 +1,10 @@
 ---
 title: När jag är fuller
-author: [
-	{
-		name: "Tore 'Pekka' Norén, B",
-		event: Sångartäflan,
-		location: KTH,
-		year: 1942
-	}
-]
+author:
+  - name: Tore "Pekka" Norén, B
+    event: Sångartäflan,
+    location: KTH,
+    year: 1942
 melody: När månen vandrar
 tags: [gasque, swe]
 ---

--- a/songs/160_Jag_kan_lara_dig_c.md
+++ b/songs/160_Jag_kan_lara_dig_c.md
@@ -1,6 +1,13 @@
 ---
 title: Jag kan lära dig C
-author: Arian och Sixten (DISK KM), DISK KM:s julfest 2011
+author: [
+	{
+		name: Arian och Sixten,
+		event: DISK KM:s julfest,
+		location: Stockholms universitet,
+		year: 2011
+	}
+]
 melody: A Whole New World
 composer: Alan Menken
 tags: [nerdy, swe]

--- a/songs/160_Jag_kan_lara_dig_c.md
+++ b/songs/160_Jag_kan_lara_dig_c.md
@@ -1,13 +1,10 @@
 ---
 title: Jag kan lära dig C
-author: [
-	{
-		name: Arian och Sixten,
-		event: DISK KM:s julfest,
-		location: Stockholms universitet,
-		year: 2011
-	}
-]
+author:
+  - name: Arian och Sixten
+    event: DISK KM:s julfest
+    location: Stockholms universitet
+    year: 2011
 melody: A Whole New World
 composer: Alan Menken
 tags: [nerdy, swe]

--- a/songs/161_Write_in_c.md
+++ b/songs/161_Write_in_c.md
@@ -1,13 +1,10 @@
 ---
 title: Write in C
-author: [
-	{
-		name: Jay Piecora,
-		location: SUNY Binghamton
-	}
-]
+author:
+  - name: Jay Piecora
+    location: SUNY Binghamton
 melody: Let It Be
-composer: John Lennon, Paul McCartney
+composer: John Lennon och Paul McCartney
 tags: [nerdy, eng]
 ---
 

--- a/songs/161_Write_in_c.md
+++ b/songs/161_Write_in_c.md
@@ -1,6 +1,11 @@
 ---
 title: Write in C
-author: Jay Piecora, SUNY Binghamton
+author: [
+	{
+		name: Jay Piecora,
+		location: SUNY Binghamton
+	}
+]
 melody: Let It Be
 composer: John Lennon, Paul McCartney
 tags: [nerdy, eng]

--- a/songs/16_Stortharligt_full.md
+++ b/songs/16_Stortharligt_full.md
@@ -1,6 +1,11 @@
 ---
 title: Störthärligt full
-author: Hittad på Handels, 1981
+author: [
+	{
+		year: 1981,
+		comment: Hittad på Handels
+	}
+]
 melody: Fat Mammy Brown
 composer: Povel Ramel
 tags: [gasque, swe]

--- a/songs/16_Stortharligt_full.md
+++ b/songs/16_Stortharligt_full.md
@@ -1,11 +1,8 @@
 ---
 title: Störthärligt full
-author: [
-	{
-		year: 1981,
-		comment: Hittad på Handels
-	}
-]
+author:
+  - year: 1981
+    comment: Hittad på Handels
 melody: Fat Mammy Brown
 composer: Povel Ramel
 tags: [gasque, swe]

--- a/songs/17_Bort_allt_vad_oro_gor.md
+++ b/songs/17_Bort_allt_vad_oro_gor.md
@@ -1,12 +1,9 @@
 ---
 title: Bort allt vad oro gör
-author: [
-	{
-		name: Carl Michael Bellman,
-		year: 1783,
-		comment: Bacchi Tempel sång nr. 17
-	}
-]
+author:
+  - name: Carl Michael Bellman
+    year: 1783
+    comment: Bacchi Tempel sång nr. 17
 composer: Carl Michael Bellman
 tags: [gasque, swe]
 ---

--- a/songs/17_Bort_allt_vad_oro_gor.md
+++ b/songs/17_Bort_allt_vad_oro_gor.md
@@ -1,6 +1,12 @@
 ---
 title: Bort allt vad oro gör
-author: Carl Michael Bellman
+author: [
+	{
+		name: Carl Michael Bellman,
+		year: 1783,
+		comment: Bacchi Tempel sång nr. 17
+	}
+]
 composer: Carl Michael Bellman
 tags: [gasque, swe]
 ---

--- a/songs/1_Danse_macabre.md
+++ b/songs/1_Danse_macabre.md
@@ -1,6 +1,11 @@
 ---
-title: Dance macabre
-author: Carl-Erik Carlstedt, Chalmers
+title: Danse macabre
+author: [
+	{
+		name: Carl-Erik Carlstedt,
+		location: Chalmers
+	}
+]
 melody: Vårvindar friska
 tags: [gasque, swe]
 ---

--- a/songs/1_Danse_macabre.md
+++ b/songs/1_Danse_macabre.md
@@ -1,11 +1,8 @@
 ---
 title: Danse macabre
-author: [
-	{
-		name: Carl-Erik Carlstedt,
-		location: Chalmers
-	}
-]
+author:
+  - name: Carl-Erik Carlstedt
+    location: Chalmers
 melody: Vårvindar friska
 tags: [gasque, swe]
 ---

--- a/songs/23_Antisnapsvisa.md
+++ b/songs/23_Antisnapsvisa.md
@@ -1,6 +1,11 @@
 ---
 title: Anti-snapsvisa
-author: Lundakarnevalen, 1986
+author: [
+	{
+		event: Lundakarnevalen,
+		year: 1986
+	}
+]
 melody: Sjösala vals
 composer: Evert Taube
 tags: [gasque, swe]

--- a/songs/23_Antisnapsvisa.md
+++ b/songs/23_Antisnapsvisa.md
@@ -1,11 +1,8 @@
 ---
 title: Anti-snapsvisa
-author: [
-	{
-		event: Lundakarnevalen,
-		year: 1986
-	}
-]
+author:
+  - event: Lundakarnevalen
+    year: 1986
 melody: Sjösala vals
 composer: Evert Taube
 tags: [gasque, swe]

--- a/songs/24_Cidervisan.md
+++ b/songs/24_Cidervisan.md
@@ -1,6 +1,12 @@
 ---
 title: Cidervisan
-author: Strängteoretiquerna, 2015
+author: [
+	{
+		name: 'Strängteoretiquerna, IT',
+		location: KTH,
+		year: 2015
+	}
+]
 melody: Rövarnas visa
 composer: Thorbjørn Egner
 tags: [gasque, swe]

--- a/songs/24_Cidervisan.md
+++ b/songs/24_Cidervisan.md
@@ -1,7 +1,7 @@
 ---
 title: Cidervisan
 author:
-  - name: Strängteoretiquerna, IT
+  - name: Strängteoretiquerna, IN
     location: KTH
     year: 2015
 melody: Rövarnas visa

--- a/songs/24_Cidervisan.md
+++ b/songs/24_Cidervisan.md
@@ -1,12 +1,9 @@
 ---
 title: Cidervisan
-author: [
-	{
-		name: 'Strängteoretiquerna, IT',
-		location: KTH,
-		year: 2015
-	}
-]
+author:
+  - name: Strängteoretiquerna, IT
+    location: KTH
+    year: 2015
 melody: Rövarnas visa
 composer: Thorbjørn Egner
 tags: [gasque, swe]

--- a/songs/25_Vi_tar_en_enkel_liten_sang.md
+++ b/songs/25_Vi_tar_en_enkel_liten_sang.md
@@ -1,6 +1,12 @@
 ---
 title: Vi tar en enkel liten sång
-author: Strängteoretiquerna, 2015
+author: [
+	{
+		name: 'Strängteoretiquerna, IT',
+		location: KTH,
+		year: 2015
+	}
+]
 melody: Med en enkel tulipan
 composer: Jules Sylvain och Sven Paddock
 tags: [gasque, swe]

--- a/songs/25_Vi_tar_en_enkel_liten_sang.md
+++ b/songs/25_Vi_tar_en_enkel_liten_sang.md
@@ -1,12 +1,9 @@
 ---
 title: Vi tar en enkel liten sång
-author: [
-	{
-		name: 'Strängteoretiquerna, IT',
-		location: KTH,
-		year: 2015
-	}
-]
+author:
+  - name: Strängteoretiquerna, IT
+    location: KTH
+    year: 2015
 melody: Med en enkel tulipan
 composer: Jules Sylvain och Sven Paddock
 tags: [gasque, swe]

--- a/songs/25_Vi_tar_en_enkel_liten_sang.md
+++ b/songs/25_Vi_tar_en_enkel_liten_sang.md
@@ -1,7 +1,7 @@
 ---
 title: Vi tar en enkel liten sång
 author:
-  - name: Strängteoretiquerna, IT
+  - name: Strängteoretiquerna, IN
     location: KTH
     year: 2015
 melody: Med en enkel tulipan

--- a/songs/26_Treocomp.md
+++ b/songs/26_Treocomp.md
@@ -1,11 +1,8 @@
 ---
 title: Treo-comp
-author: [
-	{
-		event: Lundakarnevalen,
-		year: 1986
-	}
-]
+author:
+  - event: Lundakarnevalen
+    year: 1986
 melody: Längtan till landet
 composer: Otto Lindblad
 tags: [gasque, swe]

--- a/songs/26_Treocomp.md
+++ b/songs/26_Treocomp.md
@@ -1,7 +1,12 @@
 ---
 title: Treo-comp
+author: [
+	{
+		event: Lundakarnevalen,
+		year: 1986
+	}
+]
 melody: Längtan till landet
-author: Lundakarnevalen, 1986
 composer: Otto Lindblad
 tags: [gasque, swe]
 ---

--- a/songs/29_Vit_vecka.md
+++ b/songs/29_Vit_vecka.md
@@ -1,6 +1,12 @@
 ---
 title: Vit vecka
-author: Sångarstriden Lund, 1992
+author: [
+	{
+		event: Sångarstriden,
+		location: Lund, 
+		year: 1992
+	}
+]
 melody: White Christmas
 composer: Irving Berlin
 tags: [gasque, swe]

--- a/songs/29_Vit_vecka.md
+++ b/songs/29_Vit_vecka.md
@@ -1,12 +1,9 @@
 ---
 title: Vit vecka
-author: [
-	{
-		event: Sångarstriden,
-		location: Lund, 
-		year: 1992
-	}
-]
+author:
+  - event: Sångarstriden
+    location: Lund
+    year: 1992
 melody: White Christmas
 composer: Irving Berlin
 tags: [gasque, swe]

--- a/songs/2_Porthos_visa.md
+++ b/songs/2_Porthos_visa.md
@@ -1,14 +1,11 @@
 ---
 title: Porthos visa
-author: [
-	{
-		name: 'Tord Andrén, B',
-		event: Bergsspexet,
-		location: KTH,
-		year: 1960,
-		comment: Ursprungligen Athos visa
-	}
-]
+author:
+  - name: Tord Andrén, B
+    event: Bergsspexet
+    location: KTH
+    year: 1960
+    comment: Ursprungligen Athos visa
 melody: You can't get a man with a gun
 composer: Irving Berlin
 tags: [gasque, swe]

--- a/songs/2_Porthos_visa.md
+++ b/songs/2_Porthos_visa.md
@@ -1,6 +1,14 @@
 ---
 title: Porthos visa
-author: Tore Norén, Bergsspexet, 1960
+author: [
+	{
+		name: 'Tord Andrén, B',
+		event: Bergsspexet,
+		location: KTH,
+		year: 1960,
+		comment: Ursprungligen Athos visa
+	}
+]
 melody: You can't get a man with a gun
 composer: Irving Berlin
 tags: [gasque, swe]

--- a/songs/3_Jag_ska_festa.md
+++ b/songs/3_Jag_ska_festa.md
@@ -1,6 +1,13 @@
 ---
 title: Jag ska festa
-author: Stefan 'Stege' Gennert och Anders 'Pellefjant' Bjerkén, Sångarstriden Lund, 1987
+author: [
+	{
+		name: "Stefan 'Stege' Gennert, D-86, och Anders 'Pellefjant' Bjerkén, D-87", 
+		event: Sångarstriden,
+		location: Lund,
+		year: 1987
+	}
+]
 melody: Bamsesången
 composer: Sten Carlberg
 tags: [gasque, swe]

--- a/songs/3_Jag_ska_festa.md
+++ b/songs/3_Jag_ska_festa.md
@@ -1,13 +1,10 @@
 ---
 title: Jag ska festa
-author: [
-	{
-		name: "Stefan 'Stege' Gennert, D-86, och Anders 'Pellefjant' Bjerkén, D-87", 
-		event: Sångarstriden,
-		location: Lund,
-		year: 1987
-	}
-]
+author:
+  - name: Stefan "Stege" Gennert, D-86, och Anders "Pellefjant" Bjerkén, D-87
+    event: Sångarstriden
+    location: Lund
+    year: 1987
 melody: Bamsesången
 composer: Sten Carlberg
 tags: [gasque, swe]

--- a/songs/44_Oppna_en_ohl.md
+++ b/songs/44_Oppna_en_ohl.md
@@ -1,12 +1,9 @@
 ---
 title: Öppna en öhl
-author: [
-	{
-		name: Carl Brengesjö,
-		location: KTH,
-		year: 2013
-	}
-]
+author:
+  - name: Carl Brengesjö
+    location: KTH
+    year: 2013
 melody: Öppna din dörr
 composer: Tommy Nilsson
 tags: [beer, swe]

--- a/songs/44_Oppna_en_ohl.md
+++ b/songs/44_Oppna_en_ohl.md
@@ -1,6 +1,12 @@
 ---
 title: Öppna en öhl
-author: Carl Brengesjö, 2013
+author: [
+	{
+		name: Carl Brengesjö,
+		location: KTH,
+		year: 2013
+	}
+]
 melody: Öppna din dörr
 composer: Tommy Nilsson
 tags: [beer, swe]

--- a/songs/49_Elysisk_langtan.md
+++ b/songs/49_Elysisk_langtan.md
@@ -1,12 +1,9 @@
 ---
 title: Elysisk längtan
-author: [
-	{
-		event: Sångarstriden,
-		location: Lund,
-		year: 1968
-	}
-]
+author:
+  - event: Sångarstriden
+    location: Lund
+    year: 1968
 melody: An die Freude (Ode to Joy)
 composer: Ludwig van Beethoven
 tags: [wine, swe]

--- a/songs/49_Elysisk_langtan.md
+++ b/songs/49_Elysisk_langtan.md
@@ -1,6 +1,12 @@
 ---
 title: Elysisk längtan
-author: Sångarstriden Lund, 1968
+author: [
+	{
+		event: Sångarstriden,
+		location: Lund,
+		year: 1968
+	}
+]
 melody: An die Freude (Ode to Joy)
 composer: Ludwig van Beethoven
 tags: [wine, swe]

--- a/songs/4_Lyft_ditt_valforsedda_glas.md
+++ b/songs/4_Lyft_ditt_valforsedda_glas.md
@@ -1,6 +1,12 @@
 ---
 title: Lyft ditt välförsedda glas
-author: Medicinarspexet Göteborg, 1970
+author: [
+	{
+		event: Medicinarspexet,
+		location: Göteborg,
+		year: 1970
+	}
+]
 melody: Ding dong merrily on high
 composer: Jehan Tabourot, George Ratcliffe Woodward, Charles Wood
 tags: [gasque, swe]

--- a/songs/4_Lyft_ditt_valforsedda_glas.md
+++ b/songs/4_Lyft_ditt_valforsedda_glas.md
@@ -1,12 +1,9 @@
 ---
 title: Lyft ditt välförsedda glas
-author: [
-	{
-		event: Medicinarspexet,
-		location: Göteborg,
-		year: 1970
-	}
-]
+author:
+  - event: Medicinarspexet
+    location: Göteborg
+    year: 1970
 melody: Ding dong merrily on high
 composer: Jehan Tabourot, George Ratcliffe Woodward, Charles Wood
 tags: [gasque, swe]

--- a/songs/55_Langtan_till_landet.md
+++ b/songs/55_Langtan_till_landet.md
@@ -1,6 +1,11 @@
 ---
 title: Längtan till landet
-author: Herman Sätherberg och Otto Lindblad
+author: [
+	{
+		name: Herman Sätherberg och Otto Lindblad,
+		year: 1838
+	}
+]
 composer: Herman Sätherberg och Otto Lindblad
 tags: [wine, swe]
 ---

--- a/songs/55_Langtan_till_landet.md
+++ b/songs/55_Langtan_till_landet.md
@@ -1,12 +1,9 @@
 ---
 title: Längtan till landet
-author: [
-	{
-		name: Herman Sätherberg och Otto Lindblad,
-		year: 1838
-	}
-]
-composer: Herman Sätherberg och Otto Lindblad
+author:
+  - name: Herman Sätherberg
+    year: 1838
+composer: Otto Lindblad
 tags: [wine, swe]
 ---
 

--- a/songs/57_Tjugotre.md
+++ b/songs/57_Tjugotre.md
@@ -1,11 +1,8 @@
 ---
 title: Tjugotre
-author: [
-	{
-		name: 'Carl Nisser, E-80',
-		location: KTH
-	}
-]
+author:
+  - name: Carl Nisser, E-80
+    location: KTH
 melody: Amanda Lundbom
 tags: [snaps, swe]
 ---

--- a/songs/57_Tjugotre.md
+++ b/songs/57_Tjugotre.md
@@ -1,6 +1,11 @@
 ---
 title: Tjugotre
-author: Carl Nisser, E-80
+author: [
+	{
+		name: 'Carl Nisser, E-80',
+		location: KTH
+	}
+]
 melody: Amanda Lundbom
 tags: [snaps, swe]
 ---

--- a/songs/5_Fredmans_sang_nr_21.md
+++ b/songs/5_Fredmans_sang_nr_21.md
@@ -1,11 +1,8 @@
 ---
 title: Fredmans sång nr. 21
-author: [
-	{
-		name: Carl Michael Bellman,
-		year: 1787
-	}
-]
+author:
+  - name: Carl Michael Bellman
+    year: 1787
 composer: Carl Michael Bellman
 tags: [gasque, swe]
 ---

--- a/songs/5_Fredmans_sang_nr_21.md
+++ b/songs/5_Fredmans_sang_nr_21.md
@@ -1,6 +1,11 @@
 ---
 title: Fredmans sång nr. 21
-author: Carl Michael Bellman
+author: [
+	{
+		name: Carl Michael Bellman,
+		year: 1787
+	}
+]
 composer: Carl Michael Bellman
 tags: [gasque, swe]
 ---

--- a/songs/69_Livet_ar_harligt.md
+++ b/songs/69_Livet_ar_harligt.md
@@ -1,11 +1,8 @@
 ---
 title: Livet är härligt
-author: [
-	{
-		event: Chalmersspexet Katarina II,
-		year: 1959
-	}
-]
+author:
+  - event: Chalmersspexet Katarina II
+    year: 1959
 melody: Röda kavalleriet (Polyushko-Pole)
 composer: Lev Knipper
 tags: [snaps, swe]

--- a/songs/69_Livet_ar_harligt.md
+++ b/songs/69_Livet_ar_harligt.md
@@ -1,6 +1,11 @@
 ---
 title: Livet är härligt
-author: Chalmersspexet Katarina II, 1959
+author: [
+	{
+		event: Chalmersspexet Katarina II,
+		year: 1959
+	}
+]
 melody: Röda kavalleriet (Polyushko-Pole)
 composer: Lev Knipper
 tags: [snaps, swe]

--- a/songs/6_Harjarevisan.md
+++ b/songs/6_Harjarevisan.md
@@ -1,6 +1,11 @@
 ---
 title: Härjarevisan
-author: Lundaspexet Djingis Khan, 1954
+author: [
+	{
+		event: Lundaspexet Djingis Khan,
+		year: 1954
+	}
+]
 melody: Gärdebylåten
 tags: [gasque, swe]
 ---

--- a/songs/6_Harjarevisan.md
+++ b/songs/6_Harjarevisan.md
@@ -1,11 +1,8 @@
 ---
 title: Härjarevisan
-author: [
-	{
-		event: Lundaspexet Djingis Khan,
-		year: 1954
-	}
-]
+author:
+  - event: Lundaspexet Djingis Khan
+    year: 1954
 melody: Gärdebylåten
 tags: [gasque, swe]
 ---

--- a/songs/70_Vikingen.md
+++ b/songs/70_Vikingen.md
@@ -1,6 +1,13 @@
 ---
 title: Vikingen
-author: Sångarstriden, Lund, 1981
+author: [
+	{
+		name: E-Sektionen,
+		event: Sångarstriden,
+		location: Lund,
+		year: 1981
+	}
+]
 melody: When Johnny comes marching home
 tags: [snaps, swe]
 ---

--- a/songs/70_Vikingen.md
+++ b/songs/70_Vikingen.md
@@ -1,13 +1,10 @@
 ---
 title: Vikingen
-author: [
-	{
-		name: E-Sektionen,
-		event: Sångarstriden,
-		location: Lund,
-		year: 1981
-	}
-]
+author:
+  - name: E-Sektionen
+    event: Sångarstriden
+    location: Lund
+    year: 1981
 melody: When Johnny comes marching home
 tags: [snaps, swe]
 ---

--- a/songs/71_En_gang_daran.md
+++ b/songs/71_En_gang_daran.md
@@ -1,6 +1,10 @@
 ---
 title: En gång däran
-author: Evert Taube
+author: [
+	{
+		name: Evert Taube
+	}
+]
 composer: Evert Taube
 tags: [snaps, swe]
 ---

--- a/songs/71_En_gang_daran.md
+++ b/songs/71_En_gang_daran.md
@@ -1,10 +1,7 @@
 ---
 title: En gång däran
-author: [
-	{
-		name: Evert Taube
-	}
-]
+author:
+  - name: Evert Taube
 composer: Evert Taube
 tags: [snaps, swe]
 ---

--- a/songs/78_Grav_ur_tundran.md
+++ b/songs/78_Grav_ur_tundran.md
@@ -1,12 +1,9 @@
 ---
 title: Gräv ur tundran
-author: [
-	{
-		event: Ekonomspexet Lenin,
-		location: Stockholms universitet,
-		year: 1989
-	}
-]
+author:
+  - event: Ekonomspexet Lenin
+    location: Stockholms universitet
+    year: 1989
 melody: Katjuscha
 composer: Matvey Blanter
 tags: [snaps, swe]

--- a/songs/78_Grav_ur_tundran.md
+++ b/songs/78_Grav_ur_tundran.md
@@ -1,6 +1,12 @@
 ---
 title: Gräv ur tundran
-author: Ekonomspexet Lenin, 1989
+author: [
+	{
+		event: Ekonomspexet Lenin,
+		location: Stockholms universitet,
+		year: 1989
+	}
+]
 melody: Katjuscha
 composer: Matvey Blanter
 tags: [snaps, swe]

--- a/songs/83_Hav_hav_detta_glas.md
+++ b/songs/83_Hav_hav_detta_glas.md
@@ -1,11 +1,8 @@
 ---
 title: Häv, häv detta glas
-author: [
-	{
-		name: 'Erik Rålenius, IT',
-		location: KTH
-	}
-]
+author:
+  - name: Erik Rålenius, IT
+    location: KTH
 melody: Bä, bä vita lamm
 composer: Alice Tegnér
 tags: [snaps, swe]

--- a/songs/83_Hav_hav_detta_glas.md
+++ b/songs/83_Hav_hav_detta_glas.md
@@ -1,6 +1,11 @@
 ---
 title: Häv, häv detta glas
-author: Erik Rålenius
+author: [
+	{
+		name: 'Erik Rålenius, IT',
+		location: KTH
+	}
+]
 melody: Bä, bä vita lamm
 composer: Alice Tegnér
 tags: [snaps, swe]

--- a/songs/84_Spritbolaget.md
+++ b/songs/84_Spritbolaget.md
@@ -1,6 +1,13 @@
 ---
 title: Spritbolaget
-author: Göran Svensson, Sångarstriden Lund, 1989
+author: [
+	{
+		name: Göran Svensson,
+		event: Sångarstriden,
+		location: Lund,
+		year: 1989
+	}
+]
 melody: Du käre lille snickerboa
 composer: Georg Riedel
 tags: [snaps, swe]

--- a/songs/84_Spritbolaget.md
+++ b/songs/84_Spritbolaget.md
@@ -1,13 +1,10 @@
 ---
 title: Spritbolaget
-author: [
-	{
-		name: Göran Svensson,
-		event: Sångarstriden,
-		location: Lund,
-		year: 1989
-	}
-]
+author:
+  - name: Göran Svensson
+    event: Sångarstriden
+    location: Lund
+    year: 1989
 melody: Du käre lille snickerboa
 composer: Georg Riedel
 tags: [snaps, swe]

--- a/songs/85_Rackaren.md
+++ b/songs/85_Rackaren.md
@@ -1,12 +1,9 @@
 ---
 title: Rackaren
-author: [
-	{
-		event: Kårspexet Munken,
-		location: KTH,
-		year: 1983
-	}
-]
+author:
+  - event: Kårspexet Munken
+    location: KTH
+    year: 1983
 melody: Hamburger Ebb und Fluth
 composer: Georg Philipp Telemann
 tags: [snaps, swe]

--- a/songs/85_Rackaren.md
+++ b/songs/85_Rackaren.md
@@ -1,6 +1,12 @@
 ---
 title: Rackaren
-author: Kårspexet Munken, 1983
+author: [
+	{
+		event: Kårspexet Munken,
+		location: KTH,
+		year: 1983
+	}
+]
 melody: Hamburger Ebb und Fluth
 composer: Georg Philipp Telemann
 tags: [snaps, swe]

--- a/songs/86_Ganska_nykter.md
+++ b/songs/86_Ganska_nykter.md
@@ -1,7 +1,7 @@
 ---
 title: Ganska nykter
 author:
-  - name: Strängteoretiquerna, IT
+  - name: Strängteoretiquerna, IN
     location: KTH
     year: 2015
 melody: Vi äro musikanter

--- a/songs/86_Ganska_nykter.md
+++ b/songs/86_Ganska_nykter.md
@@ -1,6 +1,12 @@
 ---
 title: Ganska nykter
-author: Strängteoretiquerna, 2015
+author: [
+	{
+		name: 'Strängteoretiquerna, IT',
+		location: KTH,
+		year: 2015
+	}
+]
 melody: Vi äro musikanter
 tags: [snaps, swe]
 ---

--- a/songs/86_Ganska_nykter.md
+++ b/songs/86_Ganska_nykter.md
@@ -1,12 +1,9 @@
 ---
 title: Ganska nykter
-author: [
-	{
-		name: 'Strängteoretiquerna, IT',
-		location: KTH,
-		year: 2015
-	}
-]
+author:
+  - name: Strängteoretiquerna, IT
+    location: KTH
+    year: 2015
 melody: Vi äro musikanter
 tags: [snaps, swe]
 ---

--- a/songs/87_Hyllningsvisa_till_Absinthen.md
+++ b/songs/87_Hyllningsvisa_till_Absinthen.md
@@ -1,12 +1,9 @@
 ---
 title: Hyllningsvisa till Absinthen
-author: [
-	{
-		name: Sing-Sing Singers,
-		location: KTH,
-		year: 2000
-	}
-]
+author:
+  - name: Sing-Sing Singers
+    location: KTH
+    year: 2000
 melody: O come all ye faithful
 tags: [snaps, swe]
 ---

--- a/songs/87_Hyllningsvisa_till_Absinthen.md
+++ b/songs/87_Hyllningsvisa_till_Absinthen.md
@@ -1,6 +1,12 @@
 ---
 title: Hyllningsvisa till Absinthen
-author: Sing-Sing Singers, 2000
+author: [
+	{
+		name: Sing-Sing Singers,
+		location: KTH,
+		year: 2000
+	}
+]
 melody: O come all ye faithful
 tags: [snaps, swe]
 ---

--- a/songs/88_Man_kan_dricka_vatten.md
+++ b/songs/88_Man_kan_dricka_vatten.md
@@ -1,6 +1,12 @@
 ---
 title: Man kan dricka vatten
-author: Datas nØllespex, 1995
+author: [
+	{
+		event: Datas nØllespex,
+		location: KTH,
+		year: 1995
+	}
+]
 melody: Vi äro musikanter
 tags: [snaps, swe]
 ---

--- a/songs/88_Man_kan_dricka_vatten.md
+++ b/songs/88_Man_kan_dricka_vatten.md
@@ -1,12 +1,9 @@
 ---
 title: Man kan dricka vatten
-author: [
-	{
-		event: Datas nØllespex,
-		location: KTH,
-		year: 1995
-	}
-]
+author:
+  - event: Datas nØllespex
+    location: KTH
+    year: 1995
 melody: Vi äro musikanter
 tags: [snaps, swe]
 ---

--- a/songs/90_Ode_till_halvan.md
+++ b/songs/90_Ode_till_halvan.md
@@ -1,11 +1,8 @@
 ---
 title: Ode till halvan
-author: [
-	{
-		name: Torgny,
-		year: 1936
-	}
-]
+author:
+  - name: Torgny
+    year: 1936
 melody: Längtan till landet
 composer: Otto Lindblad
 tags: [snaps, swe]

--- a/songs/90_Ode_till_halvan.md
+++ b/songs/90_Ode_till_halvan.md
@@ -1,6 +1,11 @@
 ---
 title: Ode till halvan
-author: Torgny, 1936
+author: [
+	{
+		name: Torgny,
+		year: 1936
+	}
+]
 melody: Längtan till landet
 composer: Otto Lindblad
 tags: [snaps, swe]

--- a/songs/94_FESTUs_punschvisa.md
+++ b/songs/94_FESTUs_punschvisa.md
@@ -1,6 +1,13 @@
 ---
-title: FESTU:s punschvisa
-melody: Tomtarnas vinternatt
+title: FestU:s punschvisa
+author: [
+	{
+		name: FestU,
+		location: Chalmers
+	}
+]
+melody: Tomtarnas julnatt
+composer: Vilhelm Sefve-Svensson
 tags: [punsch, swe]
 ---
 

--- a/songs/94_FESTUs_punschvisa.md
+++ b/songs/94_FESTUs_punschvisa.md
@@ -1,11 +1,8 @@
 ---
 title: FestU:s punschvisa
-author: [
-	{
-		name: FestU,
-		location: Chalmers
-	}
-]
+author:
+  - name: FestU
+    location: Chalmers
 melody: Tomtarnas julnatt
 composer: Vilhelm Sefve-Svensson
 tags: [punsch, swe]

--- a/songs/9_Systeme_International.md
+++ b/songs/9_Systeme_International.md
@@ -1,11 +1,8 @@
 ---
 title: Système International
-author: [
-	{
-		name: 'Anders Skog, F-75',
-		location: KTH
-	}
-]
+author:
+  - name: Anders Skog, F-75
+    location: KTH
 melody: Studentsången
 composer: Prins Gustaf av Sverige och Norge
 tags: [gasque, swe]

--- a/songs/9_Systeme_International.md
+++ b/songs/9_Systeme_International.md
@@ -1,6 +1,11 @@
 ---
 title: Système International
-author: Anders Skog, F-75
+author: [
+	{
+		name: 'Anders Skog, F-75',
+		location: KTH
+	}
+]
 melody: Studentsången
 composer: Prins Gustaf av Sverige och Norge
 tags: [gasque, swe]

--- a/src/definitions/author.ts
+++ b/src/definitions/author.ts
@@ -1,0 +1,15 @@
+export type Author = {
+	name?: string;
+	event?: string;
+	location?: string;
+	year?: number;
+	comment?: string;
+};
+
+export const VALID_AUTHOR_KEYS: Array<keyof Author> = [
+	'name',
+	'event',
+	'location',
+	'year',
+	'comment',
+];

--- a/src/definitions/song.ts
+++ b/src/definitions/song.ts
@@ -3,13 +3,21 @@ import { LegacyCategory, Tag } from './tags';
 export type Song = {
 	id: number;
 	title: string;
-	author?: string;
+	author?: Author[];
 	melody?: string;
 	composer?: string;
 	tags: Tag[];
 	sorting?: number;
 	deleted?: true;
 	content: string;
+};
+
+export type Author = {
+	name?: string;
+	event?: string;
+	location?: string;
+	year?: number;
+	comment?: string;
 };
 
 export type XmlifyableSong = Song & {

--- a/src/definitions/song.ts
+++ b/src/definitions/song.ts
@@ -1,4 +1,5 @@
 import { LegacyCategory, Tag } from './tags';
+import { Author } from './author';
 
 export type Song = {
 	id: number;
@@ -10,14 +11,6 @@ export type Song = {
 	sorting?: number;
 	deleted?: true;
 	content: string;
-};
-
-export type Author = {
-	name?: string;
-	event?: string;
-	location?: string;
-	year?: number;
-	comment?: string;
 };
 
 export type XmlifyableSong = Song & {

--- a/src/scripts/create.ts
+++ b/src/scripts/create.ts
@@ -7,7 +7,7 @@ import generateFileName from '../util/generateFileName';
 import { SONGS_FOLDER_PATH } from '../definitions/paths';
 import pushIds from '../util/pushIds';
 import { getAllSongPaths } from '../util/songs';
-import { Author } from '../definitions/song';
+import { Author } from '../definitions/author';
 
 export default function create(title: string, ...args: string[]): void {
 	if (!title) return console.error('A title for the new song must be provided!');

--- a/src/scripts/create.ts
+++ b/src/scripts/create.ts
@@ -7,7 +7,7 @@ import generateFileName from '../util/generateFileName';
 import { SONGS_FOLDER_PATH } from '../definitions/paths';
 import pushIds from '../util/pushIds';
 import { getAllSongPaths } from '../util/songs';
-import { Author } from '../definitions/author';
+import { Author, VALID_AUTHOR_KEYS } from '../definitions/author';
 
 export default function create(title: string, ...args: string[]): void {
 	if (!title) return console.error('A title for the new song must be provided!');
@@ -37,7 +37,14 @@ function generateDefaultSongFileContent(
 	}: Omit<Song, 'id' | 'title' | 'deleted' | 'content'> & { content?: string }
 ): string {
 	let contentBuilder = `---\ntitle: ${title}\n`;
-	contentBuilder += `author: ${JSON.stringify(author) || ''}\n`;
+
+	if (author) {
+		contentBuilder += `author:\n`;
+		author.forEach((a) => {
+			contentBuilder += `  - ${formatAuthor(a)}`;
+		});
+	}
+
 	contentBuilder += `melody: ${melody || ''}\n`;
 	contentBuilder += `composer: ${composer || ''}\n`;
 	contentBuilder += `tags: [${tags.join(', ')}]\n`;
@@ -88,4 +95,22 @@ function parseArgs(
 function getArgValues(args: string[], key: string): string[] {
 	const [_key, ...values] = args.find((arg) => arg.startsWith(`--${key}=`))?.split('=') || [];
 	return values;
+}
+
+function formatAuthor(author: Author): string {
+	let result = '';
+	let first = true;
+
+	for (const key of VALID_AUTHOR_KEYS) {
+		const value = author[key] ? author[key] : '';
+
+		if (first) {
+			result += `${key}: ${value}\n`;
+			first = false;
+		} else {
+			result += `    ${key}: ${value}\n`;
+		}
+	}
+
+	return result;
 }

--- a/src/scripts/create.ts
+++ b/src/scripts/create.ts
@@ -7,6 +7,7 @@ import generateFileName from '../util/generateFileName';
 import { SONGS_FOLDER_PATH } from '../definitions/paths';
 import pushIds from '../util/pushIds';
 import { getAllSongPaths } from '../util/songs';
+import { Author } from '../definitions/song';
 
 export default function create(title: string, ...args: string[]): void {
 	if (!title) return console.error('A title for the new song must be provided!');
@@ -36,7 +37,7 @@ function generateDefaultSongFileContent(
 	}: Omit<Song, 'id' | 'title' | 'deleted' | 'content'> & { content?: string }
 ): string {
 	let contentBuilder = `---\ntitle: ${title}\n`;
-	contentBuilder += `author: ${author || ''}\n`;
+	contentBuilder += `author: ${JSON.stringify(author) || ''}\n`;
 	contentBuilder += `melody: ${melody || ''}\n`;
 	contentBuilder += `composer: ${composer || ''}\n`;
 	contentBuilder += `tags: [${tags.join(', ')}]\n`;
@@ -50,11 +51,24 @@ function parseArgs(
 	args: string[]
 ): Partial<Omit<Song, 'title' | 'deleted' | 'tags'>> & { tags: Tag[] } {
 	const [idString] = getArgValues(args, 'id');
-	const [author] = getArgValues(args, 'author');
+	const [name] = getArgValues(args, 'author');
+	const [event] = getArgValues(args, 'event');
+	const [location] = getArgValues(args, 'location');
+	const [year] = getArgValues(args, 'year');
 	const [melody] = getArgValues(args, 'melody');
 	const [composer] = getArgValues(args, 'composer');
 	const tags = getArgValues(args, 'tags').filter((tag) => TAGS.includes(tag as Tag)) as Tag[];
 	const [content] = getArgValues(args, 'content');
+
+	let author: Author[] | undefined;
+	if (name || event || location || year) {
+		const authorObj: Author = {};
+		if (name) authorObj.name = name;
+		if (event) authorObj.event = event;
+		if (location) authorObj.location = location;
+		if (year) authorObj.year = parseInt(year);
+		author = [authorObj];
+	}
 
 	return {
 		id:

--- a/src/util/createSongs.ts
+++ b/src/util/createSongs.ts
@@ -1,6 +1,7 @@
 import { buildXmlString } from './xml';
 import { getAllSongs, sortSongs } from './songs';
 import { Song } from '../definitions/song';
+import { formatAuthor } from './formatAuthor';
 import { format } from 'prettier';
 import dayjs from 'dayjs';
 
@@ -14,7 +15,9 @@ export default function createSongs(updatedAt: string = dayjs().format('YYYY-MM-
 }
 
 export function createJsonSongs(songs: Song[], updatedAt: string) {
-	const sortedSongs = sortSongs(songs).map(({ sorting, ...songs }) => songs);
+	const sortedSongs = sortSongs(songs).map(({ sorting, author, ...song }) => {
+		return { ...song, author: author ? formatAuthor(author) : undefined };
+	});
 	return format(JSON.stringify({ songs: sortedSongs, updatedAt }), {
 		parser: 'json',
 		useTabs: true,

--- a/src/util/formatAuthor.ts
+++ b/src/util/formatAuthor.ts
@@ -1,0 +1,14 @@
+import { Author } from '../definitions/song';
+
+export function formatAuthor(groups: Author[]): string {
+	return groups.map(formatSingleAuthor).join('; ');
+}
+
+function formatSingleAuthor({ name, event, location, year, comment }: Author): string {
+	let details = [event, location, year].filter(Boolean).join(', ');
+	details = comment ? (details ? `${details} — ${comment}` : comment) : details;
+
+	if (!details) return name;
+	if (!name) return `(${details})`;
+	return `${name} (${details})`;
+}

--- a/src/util/formatAuthor.ts
+++ b/src/util/formatAuthor.ts
@@ -1,4 +1,4 @@
-import { Author } from '../definitions/song';
+import { Author } from '../definitions/author';
 
 export function formatAuthor(groups: Author[]): string {
 	return groups.map(formatSingleAuthor).join('; ');

--- a/src/util/xml.ts
+++ b/src/util/xml.ts
@@ -1,16 +1,17 @@
 import { Song, XmlifyableSong } from '../definitions/song';
-import { LegacyCategory, LEGACY_MAP, LEGACY_ORDER, UNKNOWN } from '../definitions/tags';
+import { LegacyCategory, LEGACY_MAP, UNKNOWN } from '../definitions/tags';
 import { sortXmlifyableSongs } from './songs';
+import { formatAuthor } from './formatAuthor';
 
 export const SONGS_DESCRIPTION =
-	'IN-sektionens sångbok, Strängteoretiquernas reviderade version (2009-2015)';
+	'IT-sektionens sångbok, Strängteoretiquernas reviderade version (2009-2015)';
 
 function songToXmlAttributes(song: XmlifyableSong, withId: boolean): string {
 	let attributes = `\n\t\tname="${song.title}"`;
 
 	if (withId) attributes += `\n\t\tid="${song.id}"`;
 
-	if (song.author) attributes += `\n\t\tauthor="${song.author}"`;
+	if (song.author) attributes += `\n\t\tauthor="${formatAuthor(song.author)}"`;
 	if (song.composer) attributes += `\n\t\tcomposer="${song.composer}"`;
 	if (song.melody) attributes += `\n\t\tmelody="${song.melody}"`;
 	attributes += `\n\t\tcategory="${song.category}"`;

--- a/test/songFiles.test.ts
+++ b/test/songFiles.test.ts
@@ -31,9 +31,21 @@ describe('All songs have valid data', () => {
 
 		songs.forEach((song) => {
 			expect(typeof song.title).toBe('string');
-			expect(typeof song.author).toMatch(/(string|undefined)/);
-			expect(typeof song.composer).toMatch(/(string|undefined)/);
-			expect(typeof song.melody).toMatch(/(string|undefined)/);
+
+			expect(Array.isArray(song.author) || song.author === undefined).toBeTruthy();
+			if (song.author) {
+				song.author.forEach((author) => {
+					expect(typeof author).toBe('object');
+					if ('name' in author) expect(typeof author.name).toBe('string');
+					if ('event' in author) expect(typeof author.event).toBe('string');
+					if ('location' in author) expect(typeof author.location).toBe('string');
+					if ('year' in author) expect(typeof author.year).toBe('number');
+					if ('comment' in author) expect(typeof author.comment).toBe('string');
+				});
+			}
+
+			if (song.composer) expect(typeof song.composer).toBe('string');
+			if (song.melody) expect(typeof song.melody).toBe('string');
 			if (typeof song.deleted === 'boolean') expect(song.deleted).toBeTruthy();
 			else expect(song.deleted).toBeUndefined();
 

--- a/test/songFiles.test.ts
+++ b/test/songFiles.test.ts
@@ -3,6 +3,7 @@ import matter from 'gray-matter';
 import { validMetaKeys } from '../src/definitions/song';
 import { TAGS } from '../src/definitions/tags';
 import { getAllSongPaths, getAllSongs } from '../src/util/songs';
+import { VALID_AUTHOR_KEYS } from '../src/definitions/author';
 
 describe('All files in songs folder are songs', () => {
 	test('All files are markdown', () => {
@@ -36,6 +37,14 @@ describe('All songs have valid data', () => {
 			if (song.author) {
 				song.author.forEach((author) => {
 					expect(typeof author).toBe('object');
+
+					Object.keys(author).forEach((key) => {
+						expect(
+							VALID_AUTHOR_KEYS,
+							`Song with ID=${song.id} and title '${song.title}' contains the invalid author field '${key}'`
+						).toContain(key);
+					});
+
 					if ('name' in author) expect(typeof author.name).toBe('string');
 					if ('event' in author) expect(typeof author.event).toBe('string');
 					if ('location' in author) expect(typeof author.location).toBe('string');

--- a/test/songFiles.test.ts
+++ b/test/songFiles.test.ts
@@ -45,11 +45,15 @@ describe('All songs have valid data', () => {
 						).toContain(key);
 					});
 
-					if ('name' in author) expect(typeof author.name).toBe('string');
-					if ('event' in author) expect(typeof author.event).toBe('string');
-					if ('location' in author) expect(typeof author.location).toBe('string');
-					if ('year' in author) expect(typeof author.year).toBe('number');
-					if ('comment' in author) expect(typeof author.comment).toBe('string');
+					VALID_AUTHOR_KEYS.forEach((key) => {
+						if (key in author && author[key]) {
+							if (key === 'year') {
+								expect(typeof author[key]).toBe('number');
+							} else {
+								expect(typeof author[key]).toBe('string');
+							}
+						}
+					});
 				});
 			}
 


### PR DESCRIPTION
Adding a new `Author` type with name, event, location, year and a comment in order to format all author tags the same way. The new type gets formatted into the following format `Name (Event, Location, Year - Comment)` and saved to the existing author tag for the song when building the songs.

I did not implement separate first, last and nicknames as well as the program as I felt it was enough to write that in the name field to not make the `Author` type too complex to fill.

As this is a breaking change for song format, the version gets bumped to 2.0.0. However, the output from songs.json/xml will still be the same and is backwards compatible with the old format, so songbooks that use them will not have to update anything.

When going through the songs and updating to the new layout, I also updated the missing author information for some songs.

Resolves #9 