### PR TITLE
Remove branch name from testing workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,9 +1,8 @@
 name: Tests
 on:
   push:
+    branches: [master]
   pull_request:
-    branches:
-      - main
 
 jobs:
   tests:


### PR DESCRIPTION
Partially beacuse it was wrong making it impossible to run on PRs from forks, but also theres really no need to limit to master since if a PR would be made to another branch there's probably a good reason and test should be allowed to run.

It was accidentally main instead of master causing it to be impossible to run