### PR TITLE
Fix build commit message and build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,7 @@ jobs:
           git config --global user.name 'Songbird Bot'
           git config --global user.email 'itsektionen-webmaster@users.noreply.github.com'
           git add dist
-          git commit -m "\
-          ${{ steps.commit-title.outputs.out }}\
-          \n\n\
-          Build was created as a result of commit ${{ github.event.workflow_run.head_commit.id }}\n[skip actions]"
+          git commit -m "${{ steps.commit-title.outputs.out }}" \
+          -m "Build was created as a result of commit ${{ github.event.workflow_run.head_commit.id }}" \
+          -m "[skip actions]"
           git push

--- a/src/github/songChanges.ts
+++ b/src/github/songChanges.ts
@@ -8,7 +8,7 @@ export default async function (): Promise<boolean> {
 	if (typeof lastUpdatedAt !== 'string' || !lastUpdatedAt.match(isoDateRegex)) return true;
 
 	const songs = createSongs(lastUpdatedAt);
-	if (songs.json !== oldSongs.json) return true;
+	if ((await songs.json) !== oldSongs.json) return true;
 	if (songs.xml !== oldSongs.xml) return true;
 	if (songs.xmlNoIds !== oldSongs.xmlNoIds) return true;
 


### PR DESCRIPTION
Fix so the build messages do not look like the following `[Build for changes made at 2025-03-23 04:49:37\n\nBuild was created as a result of commit 9790afe\n[skip actions]`

Instead, the second two parts will be in the commit description.